### PR TITLE
chore: ensure node_modules ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Node modules and package managers
-node_modules
+node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary
- explicitly ignore all `node_modules` directories via `.gitignore`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 11 errors, 2321 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b2bedcffd8832181c662d4fc9abe26