### PR TITLE
refactor: memoize styles

### DIFF
--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -4,7 +4,7 @@
  * Supports variants, sizes, haptic feedback, and accessibility
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   TouchableOpacity,
   TouchableOpacityProps,
@@ -106,7 +106,7 @@ export const Button: React.FC<ButtonProps> = ({
     
     onPress?.(event);
   };
-  const getButtonStyles = (): ViewStyle => {
+  const buttonStyles = useMemo((): ViewStyle => {
     const baseStyle: ViewStyle = {
       flexDirection: 'row',
       alignItems: 'center',
@@ -115,7 +115,6 @@ export const Button: React.FC<ButtonProps> = ({
       ...tokens.Shadows.md,
     };
 
-    // Size styles
     const sizeStyles = {
       small: {
         paddingHorizontal: tokens.Spacing.md,
@@ -132,16 +131,12 @@ export const Button: React.FC<ButtonProps> = ({
         paddingVertical: tokens.Spacing.lg,
         minHeight: 52,
       },
-    };
+    } as const;
 
-    // Variant styles
     let variantStyles: ViewStyle = {};
-    
     switch (variant) {
       case 'primary':
-        variantStyles = {
-          backgroundColor: colors.interactive.primary,
-        };
+        variantStyles = { backgroundColor: colors.interactive.primary };
         break;
       case 'secondary':
         variantStyles = {
@@ -151,31 +146,20 @@ export const Button: React.FC<ButtonProps> = ({
         };
         break;
       case 'tertiary':
-        variantStyles = {
-          backgroundColor: 'transparent',
-        };
+        variantStyles = { backgroundColor: 'transparent' };
         break;
       case 'danger':
-        variantStyles = {
-          backgroundColor: colors.interactive.danger,
-        };
+        variantStyles = { backgroundColor: colors.interactive.danger };
         break;
       case 'success':
-        variantStyles = {
-          backgroundColor: colors.interactive.success,
-        };
+        variantStyles = { backgroundColor: colors.interactive.success };
         break;
     }
 
-    // Disabled styles
     if (disabled) {
-      variantStyles = {
-        ...variantStyles,
-        opacity: 0.5,
-      };
+      variantStyles = { ...variantStyles, opacity: 0.5 };
     }
 
-    // Full width
     const widthStyle = fullWidth ? { width: '100%' as const } : {};
 
     return {
@@ -184,12 +168,11 @@ export const Button: React.FC<ButtonProps> = ({
       ...variantStyles,
       ...widthStyle,
     };
-  };
+  }, [variant, size, fullWidth, disabled, tokens, colors]);
 
-  // Get text color based on variant
-  const getTextColor = () => {
+  const textColor = useMemo(() => {
     if (disabled) return colors.text.tertiary;
-    
+
     switch (variant) {
       case 'primary':
       case 'danger':
@@ -202,10 +185,9 @@ export const Button: React.FC<ButtonProps> = ({
       default:
         return colors.text.inverse;
     }
-  };
+  }, [variant, disabled, colors]);
 
-  // Get text variant based on size
-  const getTextVariant = () => {
+  const textVariant = useMemo(() => {
     switch (size) {
       case 'small':
         return 'labelMedium' as const;
@@ -216,19 +198,14 @@ export const Button: React.FC<ButtonProps> = ({
       default:
         return 'labelLarge' as const;
     }
-  };
+  }, [size]);
 
-  // Get gradient colors for primary variant
-  const getGradientColors = () => {
+  const gradientColors = useMemo(() => {
     if (variant === 'primary') {
       return [colors.interactive.primary, colors.interactive.primaryHover];
     }
     return [colors.interactive.primary, colors.interactive.primary];
-  };
-
-  const buttonStyles = getButtonStyles();
-  const textColor = getTextColor();
-  const textVariant = getTextVariant();
+  }, [variant, colors]);
 
   const ButtonContent = () => (
     <>
@@ -283,7 +260,7 @@ export const Button: React.FC<ButtonProps> = ({
         {...props}
       >
         <LinearGradient
-          colors={getGradientColors() as [string, string, ...string[]]}
+          colors={gradientColors as [string, string, ...string[]]}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 1 }}
           style={[

--- a/apps/mobile/src/components/ui/Text.tsx
+++ b/apps/mobile/src/components/ui/Text.tsx
@@ -4,7 +4,7 @@
  * Supports semantic variants, responsive sizing, and accessibility
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Text as RNText, TextProps as RNTextProps } from 'react-native';
 import { useColors, useTokens } from '../../design-system/ThemeProvider';
 
@@ -57,8 +57,7 @@ export const Text: React.FC<TextProps> = ({
   const colors = useColors();
   const tokens = useTokens();
 
-  // Get typography style based on variant
-  const getTypographyStyle = () => {
+  const typographyStyle = useMemo(() => {
     switch (variant) {
       case 'displayLarge':
         return tokens.Typography.display.large;
@@ -93,11 +92,13 @@ export const Text: React.FC<TextProps> = ({
       default:
         return tokens.Typography.body.medium;
     }
-  };
+  }, [variant, tokens]);
 
-  // Get color based on variant or custom color
-  const getTextColor = () => {
-    if (color.startsWith('#') || color.startsWith('rgb')) {
+  const textColorValue = useMemo(() => {
+    if (
+      typeof color === 'string' &&
+      (color.startsWith('#') || color.startsWith('rgb'))
+    ) {
       return color;
     }
 
@@ -123,10 +124,9 @@ export const Text: React.FC<TextProps> = ({
       default:
         return colors.text.primary;
     }
-  };
+  }, [color, colors]);
 
-  // Get font weight
-  const getFontWeight = () => {
+  const fontWeightValue = useMemo(() => {
     if (weight) {
       switch (weight) {
         case 'normal':
@@ -141,16 +141,19 @@ export const Text: React.FC<TextProps> = ({
           return weight;
       }
     }
-    return getTypographyStyle().fontWeight;
-  };
+    return typographyStyle.fontWeight;
+  }, [weight, typographyStyle]);
 
-  const textStyle = {
-    ...getTypographyStyle(),
-    fontWeight: getFontWeight(),
-    color: getTextColor(),
-    textAlign: align,
-    fontFamily: 'Inter', // Using Inter font from global.css
-  };
+  const textStyle = useMemo(
+    () => ({
+      ...typographyStyle,
+      fontWeight: fontWeightValue,
+      color: textColorValue,
+      textAlign: align,
+      fontFamily: 'Inter', // Using Inter font from global.css
+    }),
+    [typographyStyle, fontWeightValue, textColorValue, align]
+  );
 
   // Determine accessibility role based on variant
   const getDefaultAccessibilityRole = () => {


### PR DESCRIPTION
## Summary
- memoize Button styles and colors to avoid unnecessary recalculations
- memoize Text typography styles and colors

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck` *(fails: textScaling.ts parse errors)*
- `npx react-devtools` *(fails: requires electron/react-devtools install)*

------
https://chatgpt.com/codex/tasks/task_e_68b2befa5d1c83219be8e6e88371f6a6