### PR TITLE
Memoize glass helpers and reuse styles

### DIFF
--- a/apps/mobile/src/components/ui/GlassCard.tsx
+++ b/apps/mobile/src/components/ui/GlassCard.tsx
@@ -4,12 +4,13 @@
  * Features glassmorphism effects, interactive animations, and proper accessibility
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   View,
   ViewStyle,
   TouchableOpacity,
   TouchableOpacityProps,
+  StyleSheet,
 } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -135,9 +136,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
     };
   });
 
-  // Get card styles based on variant and size
-  const getCardStyles = (): ViewStyle => {
-    // Size styles
+  const cardStyles = useMemo<ViewStyle>(() => {
     const sizeStyles = {
       small: {
         padding: tokens.Spacing.md,
@@ -151,48 +150,39 @@ export const GlassCard: React.FC<GlassCardProps> = ({
         padding: tokens.Spacing.xl,
         borderRadius: borderRadius || tokens.BorderRadius['2xl'],
       },
-    };
+    } as const;
 
     return {
       ...sizeStyles[size],
-      overflow: 'hidden',
-    };
-  };
+      ...styles.container,
+    } as ViewStyle;
+  }, [size, borderRadius, tokens]);
 
-  // Get variant-specific background and styling
-  const getVariantStyles = (): {
-    backgroundColor?: string;
-    borderColor?: string;
-    borderWidth?: number;
-    tint?: 'light' | 'dark' | 'systemMaterial';
-  } => {
-    const tintColors = isDark 
+  const variantStyles = useMemo(() => {
+    const tintColors = isDark
       ? tokens.GlassmorphismTokens.tintColors.dark
       : tokens.GlassmorphismTokens.tintColors.light;
-    
+
     switch (variant) {
       case 'elevated':
         return {
           backgroundColor: withOpacity(colors.background.elevated, 0.9),
           tint: isDark ? 'dark' : 'light',
         };
-        
       case 'outlined':
         return {
           backgroundColor: 'transparent',
-          borderColor: isDark 
+          borderColor: isDark
             ? tokens.GlassmorphismTokens.borderColors.dark.regular
             : tokens.GlassmorphismTokens.borderColors.light.regular,
           borderWidth: 1,
           tint: isDark ? 'dark' : 'light',
         };
-        
       case 'filled':
         return {
           backgroundColor: withOpacity(colors.background.secondary, 0.8),
           tint: isDark ? 'dark' : 'light',
         };
-        
       case 'translucent':
       default:
         return {
@@ -200,22 +190,18 @@ export const GlassCard: React.FC<GlassCardProps> = ({
           tint: 'systemMaterial',
         };
     }
-  };
+  }, [variant, isDark, colors, tokens]);
 
-  const cardStyles = getCardStyles();
-  const variantStyles = getVariantStyles();
-
-  // Generate accessibility properties
-  const getAccessibilityProps = () => {
+  const accessibilityProps = useMemo(() => {
     const defaultRole = interactive ? 'button' : 'text';
     const role = accessibilityRole || defaultRole;
-    
-    const defaultLabel = interactive 
-      ? (accessibilityLabel || 'Interactive card')
+
+    const defaultLabel = interactive
+      ? accessibilityLabel || 'Interactive card'
       : accessibilityLabel;
-    
+
     const defaultHint = interactive
-      ? (accessibilityHint || 'Double tap to interact with this card')
+      ? accessibilityHint || 'Double tap to interact with this card'
       : accessibilityHint;
 
     return {
@@ -225,7 +211,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
       accessibilityRole: role,
       testID,
     };
-  };
+  }, [interactive, accessibilityRole, accessibilityLabel, accessibilityHint, testID]);
 
   // Render card content
   const renderCardContent = () => {
@@ -276,7 +262,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
           onPressIn={handlePressIn}
           onPressOut={handlePressOut}
           activeOpacity={1} // We handle opacity with animations
-          {...getAccessibilityProps()}
+          {...accessibilityProps}
           {...(props as TouchableOpacityProps)}
         >
           {renderCardContent()}
@@ -286,13 +272,16 @@ export const GlassCard: React.FC<GlassCardProps> = ({
   }
 
   return (
-    <View 
-      style={style}
-      {...getAccessibilityProps()}
-    >
+    <View style={style} {...accessibilityProps}>
       {renderCardContent()}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    overflow: 'hidden',
+  },
+});
 
 export default GlassCard;

--- a/apps/mobile/src/components/ui/GlassToggle.tsx
+++ b/apps/mobile/src/components/ui/GlassToggle.tsx
@@ -4,10 +4,11 @@
  * Features translucent track, smooth thumb animations, and haptic feedback
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   TouchableOpacity,
   ViewStyle,
+  StyleSheet,
 } from 'react-native';
 import Animated, {
   useSharedValue,
@@ -73,44 +74,22 @@ export const GlassToggle: React.FC<GlassToggleProps> = ({
     toggleProgress.value = withSpring(value ? 1 : 0, tokens.SpringAnimations.toggle);
   }, [value]);
   
-  // Get dimensions based on size
-  const getDimensions = () => {
+  const dimensions = useMemo(() => {
     switch (size) {
       case 'small':
-        return {
-          width: 36,
-          height: 20,
-          thumbSize: 16,
-          padding: 2,
-          borderRadius: 10,
-        };
+        return { width: 36, height: 20, thumbSize: 16, padding: 2, borderRadius: 10 };
       case 'large':
-        return {
-          width: 56,
-          height: 32,
-          thumbSize: 28,
-          padding: 2,
-          borderRadius: 16,
-        };
-      default: // medium
-        return {
-          width: 44,
-          height: 24,
-          thumbSize: 20,
-          padding: 2,
-          borderRadius: 12,
-        };
+        return { width: 56, height: 32, thumbSize: 28, padding: 2, borderRadius: 16 };
+      default:
+        return { width: 44, height: 24, thumbSize: 20, padding: 2, borderRadius: 12 };
     }
-  };
-  
-  const dimensions = getDimensions();
-  
-  // Get colors based on variant
-  const getVariantColors = () => {
-    const tintColors = isDark 
+  }, [size]);
+
+  const variantColors = useMemo(() => {
+    const tintColors = isDark
       ? tokens.GlassmorphismTokens.tintColors.dark
       : tokens.GlassmorphismTokens.tintColors.light;
-    
+
     switch (variant) {
       case 'success':
         return {
@@ -133,9 +112,7 @@ export const GlassToggle: React.FC<GlassToggleProps> = ({
           activeTint: tintColors.primary,
         };
     }
-  };
-  
-  const variantColors = getVariantColors();
+  }, [variant, isDark, colors, tokens]);
   
   // Handle press
   const handlePress = () => {
@@ -206,22 +183,26 @@ export const GlassToggle: React.FC<GlassToggleProps> = ({
     };
   });
   
-  // Track container style
-  const trackStyle: ViewStyle = {
-    width: dimensions.width,
-    height: dimensions.height,
-    borderRadius: dimensions.borderRadius,
-    padding: dimensions.padding,
-    opacity: disabled ? 0.5 : 1,
-  };
-  
-  // Thumb style
-  const thumbStyle: ViewStyle = {
-    width: dimensions.thumbSize,
-    height: dimensions.thumbSize,
-    borderRadius: dimensions.thumbSize / 2,
-    ...tokens.Shadows.sm,
-  };
+  const trackStyle = useMemo<ViewStyle>(
+    () => ({
+      width: dimensions.width,
+      height: dimensions.height,
+      borderRadius: dimensions.borderRadius,
+      padding: dimensions.padding,
+      opacity: disabled ? 0.5 : 1,
+    }),
+    [dimensions, disabled]
+  );
+
+  const thumbStyle = useMemo<ViewStyle>(
+    () => ({
+      width: dimensions.thumbSize,
+      height: dimensions.thumbSize,
+      borderRadius: dimensions.thumbSize / 2,
+      ...tokens.Shadows.sm,
+    }),
+    [dimensions, tokens]
+  );
   
   return (
     <TouchableOpacity
@@ -229,7 +210,7 @@ export const GlassToggle: React.FC<GlassToggleProps> = ({
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
       disabled={disabled}
-      style={[{ alignSelf: 'flex-start' }, style]}
+      style={[styles.wrapper, style]}
       accessible={true}
       accessibilityRole="switch"
       accessibilityState={{ checked: value }}
@@ -252,5 +233,10 @@ export const GlassToggle: React.FC<GlassToggleProps> = ({
     </TouchableOpacity>
   );
 };
+const styles = StyleSheet.create({
+  wrapper: {
+    alignSelf: 'flex-start',
+  },
+});
 
 export default GlassToggle;


### PR DESCRIPTION
## Summary
- optimize glass components by memoizing style helpers
- centralize static styles with StyleSheet.create

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68b2cf15fc0c83218d63cadf5a300217