### PR TITLE
refactor: dynamic glass tints

### DIFF
--- a/apps/mobile/src/components/ui/GlassButton.tsx
+++ b/apps/mobile/src/components/ui/GlassButton.tsx
@@ -201,18 +201,22 @@ export const GlassButton: React.FC<GlassButtonProps> = ({
   };
 
   // Get tint color for glass effect
-  const getTintColor = (): string => {
-    const tintColors = isDark 
-      ? tokens.GlassmorphismTokens.tintColors.dark
-      : tokens.GlassmorphismTokens.tintColors.light;
-    
+  const getTintColor = () => {
+    const tintColors = tokens.GlassmorphismTokens.tintColors;
+
     switch (variant) {
-      case 'primary': return tintColors.primary;
-      case 'secondary': return tintColors.secondary;
-      case 'success': return tintColors.success;
-      case 'danger': return tintColors.danger;
-      case 'tertiary': return tintColors.neutral;
-      default: return tintColors.primary;
+      case 'primary':
+        return tintColors.primary;
+      case 'secondary':
+        return tintColors.secondary;
+      case 'success':
+        return tintColors.success;
+      case 'danger':
+        return tintColors.danger;
+      case 'tertiary':
+        return tintColors.neutral;
+      default:
+        return tintColors.primary;
     }
   };
 

--- a/apps/mobile/src/components/ui/GlassCard.tsx
+++ b/apps/mobile/src/components/ui/GlassCard.tsx
@@ -166,9 +166,7 @@ export const GlassCard: React.FC<GlassCardProps> = ({
     borderWidth?: number;
     tint?: 'light' | 'dark' | 'systemMaterial';
   } => {
-    const tintColors = isDark 
-      ? tokens.GlassmorphismTokens.tintColors.dark
-      : tokens.GlassmorphismTokens.tintColors.light;
+    const tintColors = tokens.GlassmorphismTokens.tintColors;
     
     switch (variant) {
       case 'elevated':

--- a/apps/mobile/src/components/ui/GlassInput.tsx
+++ b/apps/mobile/src/components/ui/GlassInput.tsx
@@ -115,9 +115,7 @@ export const GlassInput: React.FC<GlassInputProps> = ({
   
   // Get colors based on state
   const getStateColors = () => {
-    const tintColors = isDark 
-      ? tokens.GlassmorphismTokens.tintColors.dark
-      : tokens.GlassmorphismTokens.tintColors.light;
+    const tintColors = tokens.GlassmorphismTokens.tintColors;
     
     if (hasError) {
       return {

--- a/apps/mobile/src/components/ui/GlassToggle.tsx
+++ b/apps/mobile/src/components/ui/GlassToggle.tsx
@@ -107,9 +107,7 @@ export const GlassToggle: React.FC<GlassToggleProps> = ({
   
   // Get colors based on variant
   const getVariantColors = () => {
-    const tintColors = isDark 
-      ? tokens.GlassmorphismTokens.tintColors.dark
-      : tokens.GlassmorphismTokens.tintColors.light;
+    const tintColors = tokens.GlassmorphismTokens.tintColors;
     
     switch (variant) {
       case 'success':
@@ -167,9 +165,7 @@ export const GlassToggle: React.FC<GlassToggleProps> = ({
       toggleProgress.value,
       [0, 1],
       [
-        isDark 
-          ? tokens.GlassmorphismTokens.tintColors.dark.neutral
-          : tokens.GlassmorphismTokens.tintColors.light.neutral,
+        tokens.GlassmorphismTokens.tintColors.neutral,
         variantColors.activeTint,
       ]
     );

--- a/apps/mobile/src/design-system/ThemeProvider.tsx
+++ b/apps/mobile/src/design-system/ThemeProvider.tsx
@@ -258,7 +258,7 @@ export const useGlassColors = () => {
     // Provide fallback glass colors when context is not ready
     console.warn('useGlassColors called outside ThemeProvider, using fallback values');
     const glassTokens = DesignTokens.GlassmorphismTokens;
-    const tintColors = glassTokens.tintColors.light; // Default to light theme
+    const tintColors = glassTokens.tintColors; // Dynamic tint colors
     const borderColors = glassTokens.borderColors.light;
     const shadowColors = glassTokens.shadowColors.light;
     
@@ -275,7 +275,7 @@ export const useGlassColors = () => {
   const { isDark, tokens } = context;
   
   const glassTokens = tokens.GlassmorphismTokens;
-  const tintColors = isDark ? glassTokens.tintColors.dark : glassTokens.tintColors.light;
+  const tintColors = glassTokens.tintColors;
   const borderColors = isDark ? glassTokens.borderColors.dark : glassTokens.borderColors.light;
   const shadowColors = isDark ? glassTokens.shadowColors.dark : glassTokens.shadowColors.light;
   
@@ -379,16 +379,16 @@ export function getResponsiveValue<T>(values: {
  * Usage: getGlassBackground(theme, 'primary', 'regular')
  */
 export const getGlassBackground = (
-  theme: Theme, 
+  theme: Theme,
   variant: 'primary' | 'secondary' | 'success' | 'danger' | 'warning' | 'neutral' = 'primary',
   intensity: 'ultraThin' | 'thin' | 'regular' | 'thick' | 'ultraThick' = 'regular'
-): string => {
-  const isDark = theme.background.primary === theme.BaseColors.neutral[950];
+): any => {
   const glassTokens = DesignTokens.GlassmorphismTokens;
-  const tintColors = isDark ? glassTokens.tintColors.dark : glassTokens.tintColors.light;
+  const tintColors = glassTokens.tintColors;
   const opacity = glassTokens.opacity[intensity];
-  
-  return withOpacity(tintColors[variant], opacity);
+
+  const color = tintColors[variant] as any;
+  return typeof color === 'string' ? withOpacity(color, opacity) : color;
 };
 
 /**

--- a/apps/mobile/src/design-system/tokens.ts
+++ b/apps/mobile/src/design-system/tokens.ts
@@ -4,7 +4,15 @@
  * Semantic color tokens, typography scale, spacing system, and more
  */
 
-import { Appearance } from 'react-native';
+import { Appearance, Platform, DynamicColorIOS, PlatformColor } from 'react-native';
+
+// Helper to create dynamic colors across platforms
+const dynamicTintColor = (light: string, dark: string) => {
+  if (Platform.OS === 'ios') {
+    return DynamicColorIOS({ light, dark });
+  }
+  return Appearance.getColorScheme() === 'dark' ? dark : light;
+};
 
 // ============================================================================
 // iOS 26 GLASSMORPHISM TOKENS
@@ -30,26 +38,17 @@ export const GlassmorphismTokens = {
     ultra: 50,
   },
   
-  // Tinted glass colors for iOS 26 style buttons
+  // Tinted glass colors for iOS 26 style components
   tintColors: {
-    // Light mode tints
-    light: {
-      primary: 'rgba(74, 128, 240, 0.15)',
-      secondary: 'rgba(115, 115, 115, 0.08)',
-      success: 'rgba(34, 197, 94, 0.12)',
-      warning: 'rgba(245, 158, 11, 0.12)',
-      danger: 'rgba(239, 68, 68, 0.12)',
-      neutral: 'rgba(0, 0, 0, 0.04)',
-    },
-    // Dark mode tints
-    dark: {
-      primary: 'rgba(74, 128, 240, 0.25)',
-      secondary: 'rgba(255, 255, 255, 0.08)',
-      success: 'rgba(74, 222, 128, 0.18)',
-      warning: 'rgba(251, 191, 36, 0.18)',
-      danger: 'rgba(248, 113, 113, 0.18)',
-      neutral: 'rgba(255, 255, 255, 0.06)',
-    },
+    primary: dynamicTintColor('rgba(74, 128, 240, 0.15)', 'rgba(74, 128, 240, 0.25)'),
+    secondary: dynamicTintColor('rgba(115, 115, 115, 0.08)', 'rgba(255, 255, 255, 0.08)'),
+    success: dynamicTintColor('rgba(34, 197, 94, 0.12)', 'rgba(74, 222, 128, 0.18)'),
+    warning: dynamicTintColor('rgba(245, 158, 11, 0.12)', 'rgba(251, 191, 36, 0.18)'),
+    danger: dynamicTintColor('rgba(239, 68, 68, 0.12)', 'rgba(248, 113, 113, 0.18)'),
+    neutral:
+      Platform.OS === 'ios'
+        ? PlatformColor('systemFill')
+        : dynamicTintColor('rgba(0, 0, 0, 0.04)', 'rgba(255, 255, 255, 0.06)'),
   },
   
   // Glass border colors


### PR DESCRIPTION
## Summary
- build glass tint tokens using DynamicColorIOS and PlatformColor
- update glass components to reference new tint tokens
- adjust ThemeProvider utilities to align with dynamic tints

## Testing
- `npx jest`
- `npm run lint` *(fails: numerous warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cf10dfec83219ec93b1057cd5704