### PR TITLE
chore: run typecheck and tests in mobile CI

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -30,3 +30,11 @@ jobs:
         working-directory: apps/mobile
         continue-on-error: true
         run: npm run lint
+
+      - name: Typecheck
+        working-directory: apps/mobile
+        run: npm run typecheck
+
+      - name: Test
+        working-directory: apps/mobile
+        run: npm test


### PR DESCRIPTION
## Summary
- run `npm run typecheck` and `npm test` after lint in mobile CI
- ensure workflow fails on typecheck or test errors

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: "Unused '@ts-expect-error' directive" and other TS errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3f1ce65d083219fa1b0dff45d0abc