### PR TITLE
chore: configure jest and fix card animation typing

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "test": "npx jest"
+    "test": "jest"
   },
   "dependencies": {
     "@expo-google-fonts/dev": "^0.4.7",
@@ -56,11 +56,11 @@
     "expo-router": "~5.1.5",
     "expo-secure-store": "~14.2.4",
     "expo-sensors": "~14.1.4",
+    "expo-speech": "~13.1.7",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.11",
-    "expo-speech": "~13.1.7",
     "expo-three": "^8.0.0",
     "expo-updates": "~0.28.17",
     "expo-video": "~2.2.1",

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -4,19 +4,19 @@
  * Supports glass variant, subtle shadows, and interaction states
  */
 
+import * as Haptics from 'expo-haptics';
 import React from 'react';
+import { Pressable, PressableProps, View, ViewStyle } from 'react-native';
 import type { GestureResponderEvent } from 'react-native';
-import { View, ViewStyle, Pressable, PressableProps } from 'react-native';
 import Animated, {
   Easing,
-  useSharedValue,
   useAnimatedStyle,
+  useSharedValue,
   withTiming,
-  createAnimatedComponent,
 } from 'react-native-reanimated';
-import * as Haptics from 'expo-haptics';
-import { useColors, useTokens, withOpacity } from '../../design-system/ThemeProvider';
+
 import Text from './Text';
+import { useColors, useTokens, withOpacity } from '../../design-system/ThemeProvider';
 
 // ============================================================================
 // TYPES
@@ -179,14 +179,14 @@ export const Card: React.FC<CardProps> = ({
   // Accessibility
   const getAccessibilityProps = () => {
     const defaultRole = interactive ? 'button' : 'text';
-    const role = accessibilityRole || defaultRole;
+    const role = accessibilityRole ?? defaultRole;
 
     const defaultLabel = interactive
-      ? accessibilityLabel || 'Interactive card'
+      ? (accessibilityLabel ?? 'Interactive card')
       : accessibilityLabel;
 
     const defaultHint = interactive
-      ? accessibilityHint || 'Double tap to interact with this card'
+      ? (accessibilityHint ?? 'Double tap to interact with this card')
       : accessibilityHint;
 
     return {
@@ -202,7 +202,7 @@ export const Card: React.FC<CardProps> = ({
   if (interactive) {
     const { onPress, onPressIn, onPressOut, ...pressableProps } = props as InteractiveCardProps;
     const accessibilityProps = getAccessibilityProps();
-    const AnimatedPressable = createAnimatedComponent(Pressable);
+    const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
     return (
       <AnimatedPressable


### PR DESCRIPTION
## Summary
- run Jest directly without npx to avoid interactive install
- adjust card component animation to use Animated.createAnimatedComponent and proper nullish coalescing

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: 1873 warnings remain)*

------
https://chatgpt.com/codex/tasks/task_e_68b41456eb788321b6632946e4a1c7b1