### PR TITLE
docs: audit navigation

### DIFF
--- a/docs/audit-orphans-duplicates.md
+++ b/docs/audit-orphans-duplicates.md
@@ -1,0 +1,20 @@
+# Audit: Orphans & Duplicates
+
+## Routes Map
+See [routes-map.md](./routes-map.md) for full details.
+
+## Orphan Screens/Components
+- `apps/mobile/src/screens/AnalyticsScreen.tsx` – dashboard analytics screen with no navigation references.
+- `apps/mobile/src/screens/GlassComponentsDemo.tsx` – design demo not linked in navigation.
+- `apps/mobile/src/screens/SettingsScreen.tsx` – legacy settings implementation superseded by tab version.
+- `apps/mobile/src/utils/lazyLoading.tsx` – standalone lazy-loading system unused across the app.
+
+## Duplicates & Merge Plans
+### Settings variants
+- **Duplicate:** `app/(tabs)/settings.jsx` vs `screens/SettingsScreen.tsx`.
+- **Plan:** Consolidate into a single `apps/mobile/src/app/(tabs)/settings.tsx` using the richer feature set from `SettingsScreen.tsx`. Update pushes from `app/(tabs)/index.jsx` and `app/(tabs)/profile.jsx` to the canonical path and remove imports from `utils/lazyLoading.tsx`.
+
+### Auth flow
+- **Duplicate:** Global `AuthModal` (`utils/auth/useAuthModal.jsx`) and separate `LoginScreen` (`screens/LoginScreen.tsx` via `app/login.tsx`).
+- **Plan:** Merge into one `apps/mobile/src/app/login.tsx` screen that handles sign-in/sign-up. Refactor callers of `useAuthModal` to navigate to `/login` and remove the modal variant.
+

--- a/docs/routes-map.md
+++ b/docs/routes-map.md
@@ -1,0 +1,17 @@
+# Routes Map
+
+| Route | Type | File Path | Notes |
+| --- | --- | --- | --- |
+| `/` | Stack entry | apps/mobile/src/app/index.jsx | Redirects to onboarding or tabs |
+| `/login` | Stack screen | apps/mobile/src/app/login.tsx | Imports `screens/LoginScreen` |
+| `/welcome` | Onboarding screen | apps/mobile/src/app/(onboarding)/welcome.jsx | First-run flow |
+| `(tabs)` | Tab layout | apps/mobile/src/app/(tabs)/_layout.jsx | Bottom tab navigator |
+| `/` (Home tab) | Tab screen | apps/mobile/src/app/(tabs)/index.jsx | Dashboard |
+| `/expenses` | Tab screen | apps/mobile/src/app/(tabs)/expenses.jsx | Expenses overview |
+| `/groceries` | Tab screen | apps/mobile/src/app/(tabs)/groceries.jsx | Grocery list |
+| `/chores` | Tab screen | apps/mobile/src/app/(tabs)/chores.jsx | Chores list |
+| `/profile` | Tab screen | apps/mobile/src/app/(tabs)/profile.jsx | User profile |
+| `/settings` | Tab screen (hidden) | apps/mobile/src/app/(tabs)/settings.jsx | Pushed from Home/Profile |
+| `*` | Fallback | apps/mobile/src/app/+not-found.tsx | Not found screen |
+| Global `AuthModal` | Modal | apps/mobile/src/utils/auth/useAuthModal.jsx | Reusable auth modal |
+| `mates://auth/callback` | Deep link | apps/mobile/src/utils/auth/DeepLinkHandler.jsx | Supabase magic link handler |


### PR DESCRIPTION
## Summary
- add routes map for Expo Router stacks, tabs, modal, and auth deep link
- document orphan screens and duplicate auth/settings flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b450c7250483218fe940a96ab306bc