### PR TITLE
feat(ui): unify headers with themed bar and section components

### DIFF
--- a/apps/mobile/src/components/SectionHeader.tsx
+++ b/apps/mobile/src/components/SectionHeader.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { View, StyleSheet, ViewStyle } from 'react-native';
+import { Text, useTheme, useTokens } from './ui';
+
+interface SectionHeaderProps {
+  title: string;
+  icon?: React.ReactNode;
+  action?: React.ReactNode;
+  style?: ViewStyle;
+}
+
+const SectionHeader: React.FC<SectionHeaderProps> = ({ title, icon, action, style }) => {
+  const { theme: _theme } = useTheme();
+  const tokens = useTokens();
+  const target = tokens.Spacing['5xl'];
+
+  return (
+    <View
+      style={[
+        styles.container,
+        {
+          minHeight: target,
+          marginBottom: tokens.Spacing.sm,
+        },
+        style,
+      ]}
+    >
+      <View style={[styles.left, { marginRight: action ? tokens.Spacing.sm : 0 }]}> 
+        {icon && <View style={{ marginRight: tokens.Spacing.sm }}>{icon}</View>}
+        <Text variant="titleMedium" color="primary" weight="semibold">
+          {title}
+        </Text>
+      </View>
+      {action && <View style={styles.right}>{action}</View>}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  left: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  right: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default SectionHeader;
+

--- a/apps/mobile/src/components/TopBar.tsx
+++ b/apps/mobile/src/components/TopBar.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { View, Pressable, StyleSheet } from 'react-native';
+import Animated, { useSharedValue, useAnimatedStyle, withTiming, Easing } from 'react-native-reanimated';
+import { Text, Icon, useTheme, useTokens } from './ui';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+interface TopBarProps {
+  title: string;
+  onBackPress?: () => void;
+  rightAction?: React.ReactNode;
+}
+
+const TopBar: React.FC<TopBarProps> = ({ title, onBackPress, rightAction }) => {
+  const { theme } = useTheme();
+  const tokens = useTokens();
+  const target = tokens.Spacing['5xl'];
+
+  const scale = useSharedValue(1);
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
+  const handlePressIn = () => {
+    scale.value = withTiming(tokens.Animation.press.scale, {
+      duration: tokens.Animation.duration.out,
+      easing: Easing.bezier(0.2, 0.8, 0.2, 1),
+    });
+  };
+
+  const handlePressOut = () => {
+    scale.value = withTiming(1, {
+      duration: tokens.Animation.duration.in,
+      easing: Easing.bezier(0.2, 0.8, 0.2, 1),
+    });
+  };
+
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: tokens.Spacing.lg,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: theme.border.light,
+        backgroundColor: theme.background.primary,
+        minHeight: target,
+      }}
+    >
+      {onBackPress ? (
+        <AnimatedPressable
+          onPress={onBackPress}
+          onPressIn={handlePressIn}
+          onPressOut={handlePressOut}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          style={[styles.action, { width: target, height: target }, animatedStyle]}
+        >
+          <Icon name="ArrowLeft" size="md" color="primary" />
+        </AnimatedPressable>
+      ) : (
+        <View style={[styles.action, { width: target, height: target }]} />
+      )}
+
+      <Text
+        variant="titleLarge"
+        weight="bold"
+        style={{ flex: 1, textAlign: 'center' }}
+      >
+        {title}
+      </Text>
+
+      {rightAction ? (
+        <View style={[styles.action, { width: target, height: target }]}>{rightAction}</View>
+      ) : (
+        <View style={[styles.action, { width: target, height: target }]} />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  action: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+
+export default TopBar;
+

--- a/apps/mobile/src/screens/AnalyticsScreen.tsx
+++ b/apps/mobile/src/screens/AnalyticsScreen.tsx
@@ -33,6 +33,7 @@ import {
   BarChart,
   MetricsGrid,
 } from '../components/ui';
+import SectionHeader from '../components/SectionHeader';
 
 // ============================================================================
 // TYPES
@@ -555,43 +556,27 @@ export const AnalyticsScreen: React.FC = () => {
           />
 
           {/* Insights Card */}
-          <GlassCard
-            variant="translucent"
-            size="large"
-            style={{
-              padding: tokens.Spacing.lg,
-              marginBottom: tokens.Spacing.lg,
-            }}
-            accessible={true}
-            accessibilityRole="text"
-            accessibilityLabel={generateAccessibilityLabel.status('insight', 'Spending insights and recommendations')}
-          >
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                marginBottom: tokens.Spacing.md,
-              }}
-            >
-              <Icon
-                name="Lightbulb"
-                size="md"
-                color="warning"
-                style={{ marginRight: tokens.Spacing.sm }}
-              />
-              <Text
-                variant="titleMedium"
-                color="primary"
-                weight="semibold"
-              >
-                Insights & Recommendations
-              </Text>
-            </View>
+        <GlassCard
+          variant="translucent"
+          size="large"
+          style={{
+            padding: tokens.Spacing.lg,
+            marginBottom: tokens.Spacing.lg,
+          }}
+          accessible={true}
+          accessibilityRole="text"
+          accessibilityLabel={generateAccessibilityLabel.status('insight', 'Spending insights and recommendations')}
+        >
+          <SectionHeader
+            title="Insights & Recommendations"
+            icon={<Icon name="Lightbulb" size="md" color="warning" />}
+            style={{ marginBottom: tokens.Spacing.md }}
+          />
 
-            <View style={{ gap: tokens.Spacing.sm }}>
-              <Text variant="bodyMedium" color="secondary">
-                • Your food expenses increased by 15% this month. Consider meal planning to reduce costs.
-              </Text>
+          <View style={{ gap: tokens.Spacing.sm }}>
+            <Text variant="bodyMedium" color="secondary">
+              • Your food expenses increased by 15% this month. Consider meal planning to reduce costs.
+            </Text>
               <Text variant="bodyMedium" color="secondary">
                 • You're spending 23% less on transport compared to last month. Great job!
               </Text>
@@ -609,14 +594,10 @@ export const AnalyticsScreen: React.FC = () => {
               padding: tokens.Spacing.lg,
             }}
           >
-            <Text
-              variant="titleMedium"
-              color="primary"
-              weight="semibold"
+            <SectionHeader
+              title="Export Data"
               style={{ marginBottom: tokens.Spacing.md }}
-            >
-              Export Data
-            </Text>
+            />
 
             <View
               style={{

--- a/apps/mobile/src/screens/CreatePollScreen.tsx
+++ b/apps/mobile/src/screens/CreatePollScreen.tsx
@@ -1,14 +1,15 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Text, GlassInput, GlassButton, useColors, useTokens } from '@/components/ui';
+import { GlassInput, GlassButton, useTheme, useTokens } from '@/components/ui';
+import TopBar from '@/components/TopBar';
 import { usePollStore } from '@/utils/pollStore';
 
 export default function CreatePollScreen() {
   const [question, setQuestion] = useState('');
   const { createPoll } = usePollStore();
   const router = useRouter();
-  const colors = useColors();
+  const { theme } = useTheme();
   const tokens = useTokens();
 
   const handleCreate = () => {
@@ -18,37 +19,27 @@ export default function CreatePollScreen() {
   };
 
   return (
-    <View
-      style={{
-        flex: 1,
-        backgroundColor: colors.background.primary,
-        padding: tokens.Spacing.lg,
-      }}
-    >
-      <Text
-        variant="titleLarge"
-        weight="bold"
-        style={{ marginBottom: tokens.Spacing.lg }}
-      >
-        Create Poll
-      </Text>
-      <GlassInput
-        placeholder="Poll question"
-        value={question}
-        onChangeText={setQuestion}
-        variant="default"
-        size="large"
-        style={{ marginBottom: tokens.Spacing.lg }}
-      />
-      <GlassButton
-        variant="primary"
-        buttonStyle="filled"
-        size="large"
-        onPress={handleCreate}
-        disabled={!question}
-      >
-        Create
-      </GlassButton>
+    <View style={{ flex: 1, backgroundColor: theme.background.primary }}>
+      <TopBar title="Create Poll" onBackPress={() => router.back()} />
+      <View style={{ flex: 1, padding: tokens.Spacing.lg }}>
+        <GlassInput
+          placeholder="Poll question"
+          value={question}
+          onChangeText={setQuestion}
+          variant="default"
+          size="large"
+          style={{ marginBottom: tokens.Spacing.lg }}
+        />
+        <GlassButton
+          variant="primary"
+          buttonStyle="filled"
+          size="large"
+          onPress={handleCreate}
+          disabled={!question}
+        >
+          Create
+        </GlassButton>
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/screens/PollResultsScreen.tsx
+++ b/apps/mobile/src/screens/PollResultsScreen.tsx
@@ -1,44 +1,47 @@
 import React from 'react';
 import { View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { Text, GlassButton, useColors, useTokens } from '@/components/ui';
+import { Text, GlassButton, useTheme, useTokens } from '@/components/ui';
+import TopBar from '@/components/TopBar';
 import { usePollStore } from '@/utils/pollStore';
 
 export default function PollResultsScreen() {
   const { activePoll } = usePollStore();
   const router = useRouter();
-  const colors = useColors();
+  const { theme } = useTheme();
   const tokens = useTokens();
 
   return (
-    <View
-      style={{
-        flex: 1,
-        backgroundColor: colors.background.primary,
-        padding: tokens.Spacing.lg,
-        justifyContent: 'center',
-      }}
-    >
-      <Text
-        variant="titleLarge"
-        weight="bold"
-        style={{ marginBottom: tokens.Spacing.md }}
+    <View style={{ flex: 1, backgroundColor: theme.background.primary }}>
+      <TopBar
+        title={activePoll ? activePoll.question : 'No active poll'}
+        onBackPress={() => router.replace('/(tabs)')}
+      />
+      <View
+        style={{
+          flex: 1,
+          padding: tokens.Spacing.lg,
+          justifyContent: 'center',
+        }}
       >
-        {activePoll ? activePoll.question : 'No active poll'}
-      </Text>
-      {activePoll && (
-        <Text variant="bodyMedium" color="secondary" style={{ marginBottom: tokens.Spacing.lg }}>
-          Results coming soon
-        </Text>
-      )}
-      <GlassButton
-        variant="primary"
-        buttonStyle="filled"
-        size="large"
-        onPress={() => router.replace('/(tabs)')}
-      >
-        Back to Dashboard
-      </GlassButton>
+        {activePoll && (
+          <Text
+            variant="bodyMedium"
+            color="secondary"
+            style={{ marginBottom: tokens.Spacing.lg }}
+          >
+            Results coming soon
+          </Text>
+        )}
+        <GlassButton
+          variant="primary"
+          buttonStyle="filled"
+          size="large"
+          onPress={() => router.replace('/(tabs)')}
+        >
+          Back to Dashboard
+        </GlassButton>
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable TopBar and SectionHeader components using design tokens
- swap screen-level titles for TopBar in poll flows
- use SectionHeader for analytics subsections to standardize layout

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: 1790 warnings)*
- `npm run typecheck` *(fails: missing jest types)*

------
https://chatgpt.com/codex/tasks/task_e_68b469b0cab08321b9354b38fb1fd8e5