### PR TITLE
Refactor expenses list to use ListItem & Badge

### DIFF
--- a/apps/mobile/src/app/(tabs)/expenses.jsx
+++ b/apps/mobile/src/app/(tabs)/expenses.jsx
@@ -10,6 +10,7 @@ import {
   GlassButton,
   Icon,
   ListItem,
+  Badge,
   useTheme,
   useTokens
 } from '../../components/ui';
@@ -48,7 +49,7 @@ export default function ExpensesScreen() {
       paidBy: 'You',
       sharedWith: 'All roommates',
       amount: '1,200',
-      status: 'SETTLED',
+      status: 'OWED',
     },
     {
       id: '4',
@@ -57,9 +58,24 @@ export default function ExpensesScreen() {
       paidBy: 'Roommate',
       sharedWith: 'You, Roommate',
       amount: '850',
-      status: 'PENDING',
+      status: 'OWE',
     },
   ];
+
+  const getBadgeProps = (status) => {
+    switch (status) {
+      case 'PENDING':
+        return { label: 'Pending', variant: 'warn' };
+      case 'SETTLED':
+        return { label: 'Settled', variant: 'positive' };
+      case 'OWED':
+        return { label: 'Owed', variant: 'brand' };
+      case 'OWE':
+        return { label: 'Owe', variant: 'neutral' };
+      default:
+        return { label: status, variant: 'neutral' };
+    }
+  };
 
   const handleTabPress = (tab) => {
     setActiveTab(tab);
@@ -132,16 +148,45 @@ export default function ExpensesScreen() {
 
         {/* Transaction List */}
         <View style={{ marginBottom: tokens.Spacing.lg }}>
-          {transactions.map((transaction) => (
-            <ListItem
-              key={transaction.id}
-              media={<Icon name="Receipt" size="lg" color="brand" />}
-              title={transaction.title}
-              meta={`Paid by ${transaction.paidBy} • ₹${transaction.amount}`}
-              accessory={{ type: 'chevron' }}
-              onPress={() => {}}
-            />
-          ))}
+          {transactions.map((transaction) => {
+            const badge = getBadgeProps(transaction.status);
+            return (
+              <ListItem
+                key={transaction.id}
+                media={<Icon name="Receipt" size="lg" color="brand" />}
+                title={transaction.title}
+                meta={
+                  <>
+                    <Text variant="bodySmall" color="secondary">
+                      {transaction.date}
+                    </Text>
+                    <Text variant="bodySmall" color="secondary">
+                      Paid by {transaction.paidBy}
+                    </Text>
+                  </>
+                }
+                accessory={
+                  <View style={{ alignItems: 'flex-end' }}>
+                    <Text
+                      variant="bodyMedium"
+                      weight="medium"
+                      style={{ textAlign: 'right' }}
+                    >
+                      ₹{transaction.amount}
+                    </Text>
+                    <Badge
+                      variant={badge.variant}
+                      quiet
+                      style={{ marginTop: tokens.Spacing.xs }}
+                    >
+                      {badge.label}
+                    </Badge>
+                  </View>
+                }
+                onPress={() => {}}
+              />
+            );
+          })}
         </View>
 
         {/* Summary Section */}

--- a/apps/mobile/src/app/(tabs)/expenses.jsx
+++ b/apps/mobile/src/app/(tabs)/expenses.jsx
@@ -1,9 +1,7 @@
+import * as Haptics from 'expo-haptics';
 import React, { useState } from 'react';
-import {
-  View,
-  SafeAreaView,
-  ScrollView,
-} from 'react-native';
+import { ScrollView, SafeAreaView, View } from 'react-native';
+
 import {
   Text,
   GlassCard,
@@ -12,9 +10,8 @@ import {
   ListItem,
   Badge,
   useTheme,
-  useTokens
+  useTokens,
 } from '../../components/ui';
-import * as Haptics from 'expo-haptics';
 
 export default function ExpensesScreen() {
   const [activeTab, setActiveTab] = useState('all');
@@ -99,22 +96,33 @@ export default function ExpensesScreen() {
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background.primary }}>
       <ScrollView contentContainerStyle={{ padding: tokens.Spacing.lg }}>
         {/* Header */}
-        <View style={{
-          flexDirection: 'row',
-          alignItems: 'center',
-          marginBottom: tokens.Spacing.lg,
-          paddingTop: tokens.Spacing.sm
-        }}>
-          <Icon name="DollarSign" size="xl" color="brand" style={{ marginRight: tokens.Spacing.sm }} />
-          <Text variant="headlineMedium" weight="bold">Expenses</Text>
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            marginBottom: tokens.Spacing.lg,
+            paddingTop: tokens.Spacing.sm,
+          }}
+        >
+          <Icon
+            name="DollarSign"
+            size="xl"
+            color="brand"
+            style={{ marginRight: tokens.Spacing.sm }}
+          />
+          <Text variant="headlineMedium" weight="bold">
+            Expenses
+          </Text>
         </View>
 
         {/* Glass Tabs */}
-        <View style={{
-          flexDirection: 'row',
-          marginBottom: tokens.Spacing.lg,
-          gap: tokens.Spacing.sm
-        }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            marginBottom: tokens.Spacing.lg,
+            gap: tokens.Spacing.sm,
+          }}
+        >
           <GlassButton
             variant={activeTab === 'all' ? 'primary' : 'secondary'}
             buttonStyle={activeTab === 'all' ? 'tinted' : 'outlined'}
@@ -167,18 +175,10 @@ export default function ExpensesScreen() {
                 }
                 accessory={
                   <View style={{ alignItems: 'flex-end' }}>
-                    <Text
-                      variant="bodyMedium"
-                      weight="medium"
-                      style={{ textAlign: 'right' }}
-                    >
+                    <Text variant="bodyMedium" weight="medium" style={{ textAlign: 'right' }}>
                       ₹{transaction.amount}
                     </Text>
-                    <Badge
-                      variant={badge.variant}
-                      quiet
-                      style={{ marginTop: tokens.Spacing.xs }}
-                    >
+                    <Badge variant={badge.variant} quiet style={{ marginTop: tokens.Spacing.xs }}>
                       {badge.label}
                     </Badge>
                   </View>
@@ -190,62 +190,92 @@ export default function ExpensesScreen() {
         </View>
 
         {/* Summary Section */}
-        <GlassCard
-          variant="translucent"
-          size="large"
-          style={{ marginBottom: tokens.Spacing.lg }}
-        >
+        <GlassCard variant="translucent" size="large" style={{ marginBottom: tokens.Spacing.lg }}>
           <View style={{ padding: tokens.Spacing.lg }}>
-            <Text variant="titleLarge" weight="semibold" style={{ marginBottom: tokens.Spacing.md }}>
+            <Text
+              variant="titleLarge"
+              weight="semibold"
+              style={{ marginBottom: tokens.Spacing.md }}
+            >
               August Summary
             </Text>
 
-            <View style={{
-              backgroundColor: colors.background.secondary,
-              borderRadius: tokens.BorderRadius.md,
-              padding: tokens.Spacing.md
-            }}>
-              <View style={{
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                marginBottom: tokens.Spacing.sm
-              }}>
-                <Text variant="bodyMedium" color="secondary">Total Expenses:</Text>
-                <Text variant="bodyMedium" weight="medium">₹6,300</Text>
+            <View
+              style={{
+                backgroundColor: colors.background.secondary,
+                borderRadius: tokens.BorderRadius.md,
+                padding: tokens.Spacing.md,
+              }}
+            >
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  marginBottom: tokens.Spacing.sm,
+                }}
+              >
+                <Text variant="bodyMedium" color="secondary">
+                  Total Expenses:
+                </Text>
+                <Text variant="bodyMedium" weight="medium">
+                  ₹6,300
+                </Text>
               </View>
 
-              <View style={{
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                marginBottom: tokens.Spacing.sm
-              }}>
-                <Text variant="bodyMedium" color="secondary">You paid:</Text>
-                <Text variant="bodyMedium" weight="medium">₹3,650</Text>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  marginBottom: tokens.Spacing.sm,
+                }}
+              >
+                <Text variant="bodyMedium" color="secondary">
+                  You paid:
+                </Text>
+                <Text variant="bodyMedium" weight="medium">
+                  ₹3,650
+                </Text>
               </View>
 
-              <View style={{
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                marginBottom: tokens.Spacing.sm
-              }}>
-                <Text variant="bodyMedium" color="secondary">You owe:</Text>
-                <Text variant="bodyMedium" weight="medium">₹400</Text>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  marginBottom: tokens.Spacing.sm,
+                }}
+              >
+                <Text variant="bodyMedium" color="secondary">
+                  You owe:
+                </Text>
+                <Text variant="bodyMedium" weight="medium">
+                  ₹400
+                </Text>
               </View>
 
-              <View style={{
-                flexDirection: 'row',
-                justifyContent: 'space-between',
-                marginBottom: tokens.Spacing.sm
-              }}>
-                <Text variant="bodyMedium" color="secondary">You are owed:</Text>
-                <Text variant="bodyMedium" weight="medium">₹850</Text>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                  marginBottom: tokens.Spacing.sm,
+                }}
+              >
+                <Text variant="bodyMedium" color="secondary">
+                  You are owed:
+                </Text>
+                <Text variant="bodyMedium" weight="medium">
+                  ₹850
+                </Text>
               </View>
 
-              <View style={{
-                flexDirection: 'row',
-                justifyContent: 'space-between'
-              }}>
-                <Text variant="bodyMedium" color="secondary">Net balance:</Text>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <Text variant="bodyMedium" color="secondary">
+                  Net balance:
+                </Text>
                 <Text variant="bodyMedium" weight="bold" color="success">
                   +₹450
                 </Text>
@@ -255,12 +285,14 @@ export default function ExpensesScreen() {
         </GlassCard>
 
         {/* Glass Action Buttons */}
-        <View style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          marginBottom: tokens.Spacing.lg,
-          gap: tokens.Spacing.md
-        }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+            marginBottom: tokens.Spacing.lg,
+            gap: tokens.Spacing.md,
+          }}
+        >
           <GlassButton
             variant="success"
             buttonStyle="tinted"
@@ -290,4 +322,3 @@ export default function ExpensesScreen() {
     </SafeAreaView>
   );
 }
-

--- a/apps/mobile/src/app/+not-found.tsx
+++ b/apps/mobile/src/app/+not-found.tsx
@@ -7,19 +7,20 @@ import {
   useRouter,
   useSitemap,
 } from 'expo-router';
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+
 import { ErrorBoundaryWrapper } from '../../__create/SharedErrorBoundary';
 import Button from '../components/Button';
 
 interface ParentSitemap {
-  expoPages?: Array<{
+  expoPages?: {
     id: string;
     name: string;
     filePath: string;
     cleanRoute?: string;
-  }>;
+  }[];
 }
 
 function NotFoundScreen() {
@@ -29,7 +30,7 @@ function NotFoundScreen() {
   const [sitemap, setSitemap] = useState<SitemapType | ParentSitemap | null>(expoSitemap);
 
   useEffect(() => {
-    if (typeof window !== 'undefined' && window.parent && window.parent !== window) {
+    if (typeof window !== 'undefined' && window.parent !== window) {
       const handler = (event: MessageEvent) => {
         if (event.data.type === 'sandbox:sitemap') {
           window.removeEventListener('message', handler);
@@ -41,7 +42,7 @@ function NotFoundScreen() {
         {
           type: 'sandbox:sitemap',
         },
-        '*'
+        '*',
       );
       window.addEventListener('message', handler);
 
@@ -52,7 +53,7 @@ function NotFoundScreen() {
   }, []);
 
   const isExpoSitemap = sitemap === expoSitemap;
-  const missingPath = params['not-found']?.[0] || '';
+  const missingPath = params['not-found']?.[0] ?? '';
 
   const availableRoutes = useMemo(() => {
     return (
@@ -62,8 +63,8 @@ function NotFoundScreen() {
           child.contextKey !== './auth.jsx' &&
           child.contextKey !== './auth.web.jsx' &&
           child.contextKey !== './+not-found.tsx' &&
-          child.contextKey !== 'expo-router/build/views/Sitemap.js'
-      ) || []
+          child.contextKey !== 'expo-router/build/views/Sitemap.js',
+      ) ?? []
     );
   }, [expoSitemap]);
 
@@ -74,7 +75,7 @@ function NotFoundScreen() {
       const hasTabsIndex = expoSitemap?.children?.some(
         (child) =>
           child.contextKey === './(tabs)/_layout.jsx' &&
-          child.children.some((child) => child.contextKey === './(tabs)/index.jsx')
+          child.children.some((child) => child.contextKey === './(tabs)/index.jsx'),
       );
       if (isExpoSitemap) {
         if (hasTabsIndex) {
@@ -99,14 +100,14 @@ function NotFoundScreen() {
   };
 
   const handleCreatePage = useCallback(() => {
-    if (typeof window !== 'undefined' && window.parent && window.parent !== window) {
+    if (typeof window !== 'undefined' && window.parent !== window) {
       window.parent.postMessage(
         {
           type: 'sandbox:web:create',
           path: missingPath,
           view: 'mobile',
         },
-        '*'
+        '*',
       );
     }
   }, [missingPath]);
@@ -139,7 +140,7 @@ function NotFoundScreen() {
               project. But no worries, you've got options!
             </Text>
 
-            {typeof window !== 'undefined' && window.parent && window.parent !== window && (
+            {typeof window !== 'undefined' && window.parent !== window && (
               <View style={styles.createPageContainer}>
                 <View style={styles.createPageContent}>
                   <View style={styles.createPageTextContainer}>
@@ -160,10 +161,10 @@ function NotFoundScreen() {
               <View style={styles.pagesContainer}>
                 <View style={styles.pagesListContainer}>
                   <Text style={styles.pagesLabel}>MOBILE</Text>
-                  {((sitemap as ParentSitemap).expoPages || []).map((route, index: number) => (
+                  {((sitemap as ParentSitemap).expoPages ?? []).map((route, _index: number) => (
                     <TouchableOpacity
                       key={route.id}
-                      onPress={() => handleNavigate(route.cleanRoute || '')}
+                      onPress={() => handleNavigate(route.cleanRoute ?? '')}
                       style={styles.pageButton}
                     >
                       <Text style={styles.routeName}>{route.name}</Text>
@@ -175,16 +176,16 @@ function NotFoundScreen() {
               <View style={styles.pagesContainer}>
                 <View style={styles.pagesListContainer}>
                   <Text style={styles.pagesLabel}>MOBILE</Text>
-                  {(availableRoutes as SitemapType[]).map((route: SitemapType, index: number) => {
+                  {(availableRoutes as SitemapType[]).map((route: SitemapType, _index: number) => {
                     const url =
-                      typeof route.href === 'string' ? route.href : route.href?.pathname || '/';
+                      typeof route.href === 'string' ? route.href : (route.href?.pathname ?? '/');
 
                     if (url === '/(tabs)' && route.children) {
                       return route.children.map((childRoute: SitemapType) => {
                         const childUrl =
                           typeof childRoute.href === 'string'
                             ? childRoute.href
-                            : childRoute.href.pathname || '/';
+                            : (childRoute.href.pathname ?? '/');
                         const displayPath =
                           childUrl === '/(tabs)'
                             ? 'Homepage'

--- a/apps/mobile/src/components/ui/Badge.tsx
+++ b/apps/mobile/src/components/ui/Badge.tsx
@@ -5,9 +5,10 @@
  */
 
 import React from 'react';
-import { View, ViewStyle, StyleSheet } from 'react-native';
-import { useTheme, useTokens } from '../../design-system/ThemeProvider';
+import { StyleSheet, View, ViewStyle } from 'react-native';
+
 import Text from './Text';
+import { useTheme, useTokens } from '../../design-system/ThemeProvider';
 
 // ============================================================================
 // TYPES
@@ -89,8 +90,7 @@ export const Badge: React.FC<BadgeProps> = ({
     borderWidth: quiet ? StyleSheet.hairlineWidth : 0,
   };
 
-  const a11yLabel =
-    accessibilityLabel || (typeof children === 'string' ? children : undefined);
+  const a11yLabel = accessibilityLabel ?? (typeof children === 'string' ? children : undefined);
 
   return (
     <View

--- a/apps/mobile/src/components/ui/Badge.tsx
+++ b/apps/mobile/src/components/ui/Badge.tsx
@@ -13,7 +13,7 @@ import Text from './Text';
 // TYPES
 // ============================================================================
 
-type BadgeVariant = 'neutral' | 'positive' | 'warn' | 'danger';
+type BadgeVariant = 'neutral' | 'positive' | 'warn' | 'danger' | 'brand';
 
 interface BadgeProps {
   variant?: BadgeVariant;
@@ -56,6 +56,11 @@ export const Badge: React.FC<BadgeProps> = ({
   let textColor: string = theme.text.secondary;
 
   switch (variant) {
+    case 'brand':
+      backgroundColor = quiet ? 'transparent' : theme.interactive.primary;
+      borderColor = quiet ? theme.interactive.primary : 'transparent';
+      textColor = quiet ? theme.interactive.primary : theme.text.inverse;
+      break;
     case 'positive':
       backgroundColor = quiet ? 'transparent' : theme.status.successBackground;
       borderColor = quiet ? theme.status.success : 'transparent';

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -5,7 +5,7 @@ import { useTheme, useTokens } from '../../design-system/ThemeProvider';
 import Text from './Text';
 import Icon from './Icon';
 import GlassToggle from './GlassToggle';
-import StatusIndicator from './StatusIndicator';
+import Badge from './Badge';
 
 // ============================================================================
 // TYPES
@@ -13,16 +13,17 @@ import StatusIndicator from './StatusIndicator';
 
 type Density = 'comfortable' | 'compact';
 
-type BadgeVariant = 'success' | 'warning' | 'error' | 'info' | 'neutral';
+type BadgeVariant = 'neutral' | 'positive' | 'warn' | 'danger' | 'brand';
 
 type ListItemAccessory =
   | { type: 'chevron' }
   | { type: 'toggle'; value: boolean; onValueChange: (val: boolean) => void }
-  | { type: 'badge'; label: string; variant?: BadgeVariant };
+  | { type: 'badge'; label: string; variant?: BadgeVariant; quiet?: boolean }
+  | React.ReactNode;
 
 interface ListItemProps {
   title: string;
-  meta?: string;
+  meta?: React.ReactNode;
   media?: React.ReactNode;
   accessory?: ListItemAccessory;
   density?: Density;
@@ -80,6 +81,7 @@ export const ListItem: React.FC<ListItemProps> = ({
 
   const renderAccessory = () => {
     if (!accessory) return null;
+    if (React.isValidElement(accessory)) return accessory;
     switch (accessory.type) {
       case 'chevron':
         return <Icon name="ArrowRight" size="md" color="tertiary" />;
@@ -93,11 +95,9 @@ export const ListItem: React.FC<ListItemProps> = ({
         );
       case 'badge':
         return (
-          <StatusIndicator
-            variant={accessory.variant || 'neutral'}
-            label={accessory.label}
-            size="small"
-          />
+          <Badge variant={accessory.variant || 'neutral'} quiet={accessory.quiet}>
+            {accessory.label}
+          </Badge>
         );
       default:
         return null;
@@ -131,13 +131,21 @@ export const ListItem: React.FC<ListItemProps> = ({
           {title}
         </Text>
         {meta && (
-          <Text variant="bodySmall" color="secondary">
-            {meta}
-          </Text>
+          <View style={{ marginTop: tokens.Spacing.xs }}>
+            {typeof meta === 'string' ? (
+              <Text variant="bodySmall" color="secondary">
+                {meta}
+              </Text>
+            ) : (
+              meta
+            )}
+          </View>
         )}
       </View>
       {accessory && (
-        <View style={{ marginLeft: tokens.Spacing.md }}>{renderAccessory()}</View>
+        <View style={{ marginLeft: tokens.Spacing.md, alignItems: 'flex-end' }}>
+          {renderAccessory()}
+        </View>
       )}
     </View>
   );

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { Pressable, View, ViewStyle, StyleSheet } from 'react-native';
-import Animated, { Easing, useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
-import { useTheme, useTokens } from '../../design-system/ThemeProvider';
-import Text from './Text';
-import Icon from './Icon';
-import GlassToggle from './GlassToggle';
+import { Pressable, StyleSheet, View, ViewStyle } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
 import Badge from './Badge';
+import GlassToggle from './GlassToggle';
+import Icon from './Icon';
+import Text from './Text';
+import { useTheme, useTokens } from '../../design-system/ThemeProvider';
 
 // ============================================================================
 // TYPES
@@ -15,11 +21,12 @@ type Density = 'comfortable' | 'compact';
 
 type BadgeVariant = 'neutral' | 'positive' | 'warn' | 'danger' | 'brand';
 
-type ListItemAccessory =
+type ListItemAccessoryBase =
   | { type: 'chevron' }
   | { type: 'toggle'; value: boolean; onValueChange: (val: boolean) => void }
-  | { type: 'badge'; label: string; variant?: BadgeVariant; quiet?: boolean }
-  | React.ReactNode;
+  | { type: 'badge'; label: string; variant?: BadgeVariant; quiet?: boolean };
+
+type ListItemAccessory = ListItemAccessoryBase | React.ReactNode;
 
 interface ListItemProps {
   title: string;
@@ -76,32 +83,34 @@ export const ListItem: React.FC<ListItemProps> = ({
     });
   };
 
-  const paddingVertical =
-    density === 'compact' ? tokens.Spacing.md : tokens.Spacing.lg;
+  const paddingVertical = density === 'compact' ? tokens.Spacing.md : tokens.Spacing.lg;
 
   const renderAccessory = () => {
     if (!accessory) return null;
     if (React.isValidElement(accessory)) return accessory;
-    switch (accessory.type) {
-      case 'chevron':
-        return <Icon name="ArrowRight" size="md" color="tertiary" />;
-      case 'toggle':
-        return (
-          <GlassToggle
-            value={accessory.value}
-            onValueChange={accessory.onValueChange}
-            accessibilityLabel={`${title} toggle`}
-          />
-        );
-      case 'badge':
-        return (
-          <Badge variant={accessory.variant || 'neutral'} quiet={accessory.quiet}>
-            {accessory.label}
-          </Badge>
-        );
-      default:
-        return null;
+    if (typeof accessory === 'object' && 'type' in accessory) {
+      switch (accessory.type) {
+        case 'chevron':
+          return <Icon name="ArrowRight" size="md" color="tertiary" />;
+        case 'toggle':
+          return (
+            <GlassToggle
+              value={accessory.value}
+              onValueChange={accessory.onValueChange}
+              accessibilityLabel={`${title} toggle`}
+            />
+          );
+        case 'badge':
+          return (
+            <Badge variant={accessory.variant ?? 'neutral'} quiet={accessory.quiet}>
+              {accessory.label}
+            </Badge>
+          );
+        default:
+          return null;
+      }
     }
+    return <>{accessory}</>;
   };
 
   const content = (
@@ -165,7 +174,7 @@ export const ListItem: React.FC<ListItemProps> = ({
         onPressOut={handlePressOut}
         style={[containerStyle, style, animatedStyle]}
         accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel || title}
+        accessibilityLabel={accessibilityLabel ?? title}
         accessibilityHint={accessibilityHint}
         testID={testID}
       >
@@ -177,7 +186,7 @@ export const ListItem: React.FC<ListItemProps> = ({
   return (
     <View
       style={[containerStyle, style]}
-      accessibilityLabel={accessibilityLabel || title}
+      accessibilityLabel={accessibilityLabel ?? title}
       accessibilityHint={accessibilityHint}
       accessibilityRole="text"
       testID={testID}


### PR DESCRIPTION
## Summary
- refactor Expenses tab transaction list to use ListItem v2 with right-aligned amounts and status badges
- allow custom accessories and meta in ListItem and switch badge accessory to Badge v2 with new `brand` variant
- extend Badge v2 with `brand` variant for accent styling

## Testing
- `npx eslint src/app/(tabs)/expenses.jsx src/components/ui/ListItem.tsx src/components/ui/Badge.tsx`
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b4efb88a5083218cde670512730f32