### PR TITLE
refactor: use shared UI primitives

### DIFF
--- a/apps/mobile/src/app/(tabs)/expenses.jsx
+++ b/apps/mobile/src/app/(tabs)/expenses.jsx
@@ -1,11 +1,10 @@
 import * as Haptics from 'expo-haptics';
 import React, { useState } from 'react';
 import { ScrollView, SafeAreaView, View } from 'react-native';
-
 import {
   Text,
-  GlassCard,
-  GlassButton,
+  Card,
+  Button,
   Icon,
   ListItem,
   Badge,
@@ -14,15 +13,12 @@ import {
   useTokens,
 } from '../../components/ui';
 import { useExpenses } from '../../hooks';
-
 export default function ExpensesScreen() {
   const [activeTab, setActiveTab] = useState('all');
   const { theme } = useTheme();
   const colors = theme;
   const tokens = useTokens();
-
   const { data: transactions = [], isLoading } = useExpenses();
-
   const getBadgeProps = (status) => {
     switch (status) {
       case 'PENDING':
@@ -37,30 +33,25 @@ export default function ExpensesScreen() {
         return { label: status, variant: 'neutral' };
     }
   };
-
   const handleTabPress = (tab) => {
     setActiveTab(tab);
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     // In a real app, this would filter the transactions
   };
-
   const handleSettleUp = () => {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     // This would open UPI/payment options
     console.log('Open settle up options');
   };
-
   const handleAddExpense = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     // This would open the expense form
     console.log('Open add expense form');
   };
-
   const filtered =
     activeTab === 'all'
       ? transactions
       : transactions.filter((t) => t.status === activeTab.toUpperCase());
-
   if (isLoading) {
     return (
       <SafeAreaView style={{ flex: 1, backgroundColor: colors.background.primary }}>
@@ -72,7 +63,6 @@ export default function ExpensesScreen() {
       </SafeAreaView>
     );
   }
-
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: colors.background.primary }}>
       <ScrollView contentContainerStyle={{ padding: tokens.Spacing.lg }}>
@@ -95,7 +85,6 @@ export default function ExpensesScreen() {
             Expenses
           </Text>
         </View>
-
         {/* Glass Tabs */}
         <View
           style={{
@@ -104,37 +93,31 @@ export default function ExpensesScreen() {
             gap: tokens.Spacing.sm,
           }}
         >
-          <GlassButton
+          <Button
             variant={activeTab === 'all' ? 'primary' : 'secondary'}
-            buttonStyle={activeTab === 'all' ? 'tinted' : 'outlined'}
-            size="medium"
+            size="md"
             onPress={() => handleTabPress('all')}
             style={{ flex: 1 }}
           >
             All
-          </GlassButton>
-
-          <GlassButton
+          </Button>
+          <Button
             variant={activeTab === 'settled' ? 'primary' : 'secondary'}
-            buttonStyle={activeTab === 'settled' ? 'tinted' : 'outlined'}
-            size="medium"
+            size="md"
             onPress={() => handleTabPress('settled')}
             style={{ flex: 1 }}
           >
             Settled
-          </GlassButton>
-
-          <GlassButton
+          </Button>
+          <Button
             variant={activeTab === 'owe' ? 'primary' : 'secondary'}
-            buttonStyle={activeTab === 'owe' ? 'tinted' : 'outlined'}
-            size="medium"
+            size="md"
             onPress={() => handleTabPress('owe')}
             style={{ flex: 1 }}
           >
             Owe/Owed
-          </GlassButton>
+          </Button>
         </View>
-
         {/* Transaction List */}
         <View style={{ marginBottom: tokens.Spacing.lg }}>
           {filtered.map((transaction) => {
@@ -169,10 +152,8 @@ export default function ExpensesScreen() {
             );
           })}
         </View>
-
         {/* Summary Section */}
-        <GlassCard variant="translucent" size="large" style={{ marginBottom: tokens.Spacing.lg }}>
-          <View style={{ padding: tokens.Spacing.lg }}>
+        <Card variant="elevated" style={{ marginBottom: tokens.Spacing.lg }}>
             <Text
               variant="titleLarge"
               weight="semibold"
@@ -180,7 +161,6 @@ export default function ExpensesScreen() {
             >
               August Summary
             </Text>
-
             <View
               style={{
                 backgroundColor: colors.background.secondary,
@@ -202,7 +182,6 @@ export default function ExpensesScreen() {
                   ₹6,300
                 </Text>
               </View>
-
               <View
                 style={{
                   flexDirection: 'row',
@@ -217,7 +196,6 @@ export default function ExpensesScreen() {
                   ₹3,650
                 </Text>
               </View>
-
               <View
                 style={{
                   flexDirection: 'row',
@@ -232,7 +210,6 @@ export default function ExpensesScreen() {
                   ₹400
                 </Text>
               </View>
-
               <View
                 style={{
                   flexDirection: 'row',
@@ -247,7 +224,6 @@ export default function ExpensesScreen() {
                   ₹850
                 </Text>
               </View>
-
               <View
                 style={{
                   flexDirection: 'row',
@@ -263,8 +239,7 @@ export default function ExpensesScreen() {
               </View>
             </View>
           </View>
-        </GlassCard>
-
+        </Card>
         {/* Glass Action Buttons */}
         <View
           style={{
@@ -274,29 +249,25 @@ export default function ExpensesScreen() {
             gap: tokens.Spacing.md,
           }}
         >
-          <GlassButton
-            variant="success"
-            buttonStyle="tinted"
-            size="large"
+          <Button
+            variant="secondary"
+            size="lg"
             leftIcon={<Icon name="Check" size="sm" color="inverse" />}
             onPress={handleSettleUp}
             style={{ flex: 1 }}
           >
             Settle Up
-          </GlassButton>
-
-          <GlassButton
+          </Button>
+          <Button
             variant="primary"
-            buttonStyle="tinted"
-            size="large"
+            size="lg"
             leftIcon={<Icon name="Plus" size="sm" color="inverse" />}
             onPress={handleAddExpense}
             style={{ flex: 1 }}
           >
             Add Expense
-          </GlassButton>
+          </Button>
         </View>
-
         {/* Spacer for bottom tabs */}
         <View style={{ height: 80 }} />
       </ScrollView>

--- a/apps/mobile/src/app/(tabs)/groceries.jsx
+++ b/apps/mobile/src/app/(tabs)/groceries.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, Alert, SafeAreaView, ScrollView } from 'react-native';
 import {
   Text,
-  GlassCard,
+  Card,
   Icon,
   ListItem,
   Badge,
@@ -124,19 +124,15 @@ export default function GroceriesScreen() {
 
         {/* Glass Attention Banner */}
         {attentionCount > 0 && (
-          <GlassCard
-            variant="filled"
-            style={{
-              backgroundColor: colors.status.warning,
-              marginBottom: tokens.Spacing.lg
-            }}
+          <Card
+            variant="glass"
+            contentStyle={{ backgroundColor: colors.status.warning, padding: tokens.Spacing.md }}
+            style={{ marginBottom: tokens.Spacing.lg }}
           >
-            <View style={{ padding: tokens.Spacing.md }}>
-              <Text variant="titleSmall" weight="semibold" color="inverse" align="center">
-                {attentionCount} items need attention!
-              </Text>
-            </View>
-          </GlassCard>
+            <Text variant="titleSmall" weight="semibold" color="inverse" align="center">
+              {attentionCount} items need attention!
+            </Text>
+          </Card>
         )}
 
         {/* Out Items Section */}
@@ -226,7 +222,7 @@ export default function GroceriesScreen() {
         {/* Add Item Button */}
         <Button
           variant="primary"
-          size="large"
+          size="lg"
           fullWidth
           onPress={handleAddItem}
           leftIcon={<Icon name="Plus" size="md" color="inverse" />}

--- a/apps/mobile/src/app/(tabs)/profile.jsx
+++ b/apps/mobile/src/app/(tabs)/profile.jsx
@@ -4,21 +4,14 @@ import {
   SafeAreaView,
   ScrollView,
   Image,
-  Alert,
-  Pressable,
-  StyleSheet,
+  Alert
 } from 'react-native';
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated';
 import {
   Text,
-  Badge,
   ListItem,
   Icon,
+  Button,
+  Card,
   useTheme,
   useTokens,
 } from '@/components/ui';
@@ -31,45 +24,16 @@ import * as Haptics from 'expo-haptics';
 // -----------------------------------------------------------------------------
 
 const ActionChip = ({ label, onPress }) => {
-  const { accessibility } = useTheme();
   const tokens = useTokens();
-
-  const scale = useSharedValue(1);
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-  }));
-
-  const easing = Easing.bezier(0.2, 0.8, 0.2, 1);
-
-  const handlePressIn = () => {
-    if (accessibility.isReduceMotionEnabled) return;
-    scale.value = withTiming(tokens.Animation.press.scale, {
-      duration: tokens.Animation.duration.in,
-      easing,
-    });
-  };
-
-  const handlePressOut = () => {
-    if (accessibility.isReduceMotionEnabled) return;
-    scale.value = withTiming(1, {
-      duration: tokens.Animation.duration.out,
-      easing,
-    });
-  };
-
-  const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
-
   return (
-    <AnimatedPressable
+    <Button
+      variant="secondary"
+      size="sm"
       onPress={onPress}
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
-      style={[{ marginRight: tokens.Spacing.sm }, animatedStyle]}
-      accessibilityRole="button"
-      accessibilityLabel={label}
+      style={{ marginRight: tokens.Spacing.sm }}
     >
-      <Badge>{label}</Badge>
-    </AnimatedPressable>
+      {label}
+    </Button>
   );
 };
 
@@ -264,14 +228,7 @@ export default function ProfileScreen() {
             Management
           </Text>
 
-          <View
-            style={{
-              borderWidth: StyleSheet.hairlineWidth,
-              borderColor: theme.border.light,
-              borderRadius: tokens.BorderRadius.lg,
-              overflow: 'hidden',
-            }}
-          >
+          <Card variant="outlined" contentStyle={{ padding: 0 }}>
             <ListItem
               title="Manage House"
               meta="Invite members, house settings"
@@ -341,10 +298,9 @@ export default function ProfileScreen() {
               )}
               onPress={handleSignOut}
             />
-          </View>
+          </Card>
         </View>
       </ScrollView>
     </SafeAreaView>
   );
 }
-

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -1,22 +1,13 @@
-/**
- * Modern Button Component
- * Premium button with 2025 design standards
- * Supports variants, sizes, haptic feedback, and accessibility
- */
-
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Pressable,
   PressableProps,
   ActivityIndicator,
-  ViewStyle,
-  View,
   StyleSheet,
+  View,
+  ViewStyle,
 } from 'react-native';
-import { LinearGradient } from 'expo-linear-gradient';
 import * as Haptics from 'expo-haptics';
-import { useColors, useTokens } from '../../design-system/ThemeProvider';
-import Text from './Text';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -24,12 +15,23 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import Text from './Text';
+import { useTheme, useTokens } from '../../design-system/ThemeProvider';
+
 // ============================================================================
 // TYPES
 // ============================================================================
 
-type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'danger' | 'success';
-type ButtonSize = 'small' | 'medium' | 'large';
+type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'ghost'
+  | 'destructive'
+  | 'success'
+  | 'danger'
+  | 'tertiary';
+
+type ButtonSize = 'sm' | 'md' | 'lg' | 'small' | 'medium' | 'large';
 
 interface ButtonProps extends Omit<PressableProps, 'style'> {
   variant?: ButtonVariant;
@@ -40,13 +42,10 @@ interface ButtonProps extends Omit<PressableProps, 'style'> {
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   hapticFeedback?: boolean;
-  gradient?: boolean;
   style?: ViewStyle;
   children: React.ReactNode;
-  // Accessibility props
   accessibilityLabel?: string;
   accessibilityHint?: string;
-  accessibilityRole?: 'button' | 'link' | 'none';
   testID?: string;
 }
 
@@ -56,285 +55,181 @@ interface ButtonProps extends Omit<PressableProps, 'style'> {
 
 export const Button: React.FC<ButtonProps> = ({
   variant = 'primary',
-  size = 'medium',
+  size = 'md',
   fullWidth = false,
   loading = false,
   disabled = false,
   leftIcon,
   rightIcon,
   hapticFeedback = true,
-  gradient = false,
   style,
   children,
   onPress,
   accessibilityLabel,
   accessibilityHint,
-  accessibilityRole = 'button',
   testID,
   ...props
 }) => {
-  const colors = useColors();
+  const { theme, accessibility } = useTheme();
   const tokens = useTokens();
 
   const scale = useSharedValue(1);
-  const iconOffset = useSharedValue(0);
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-  }));
-
-  const iconAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: iconOffset.value }],
-  }));
-
-  // Generate accessibility label if not provided
-  const getAccessibilityLabel = () => {
-    if (accessibilityLabel) return accessibilityLabel;
-    
-    const childText = typeof children === 'string' ? children : 'Button';
-    if (loading) return `${childText}, Loading`;
-    if (disabled) return `${childText}, Disabled`;
-    return childText;
-  };
-
-  // Generate accessibility hint if not provided
-  const getAccessibilityHint = () => {
-    if (accessibilityHint) return accessibilityHint;
-    
-    if (loading) return 'Please wait while the action is being processed';
-    if (disabled) return 'This button is currently disabled';
-    
-    switch (variant) {
-      case 'danger':
-        return 'Double tap to perform a destructive action';
-      case 'primary':
-        return 'Double tap to perform the primary action';
-      default:
-        return 'Double tap to activate';
-    }
-  };
-
-  // Handle press with haptic feedback
-  const handlePress = (event: any) => {
-    if (disabled || loading) return;
-    
-    if (hapticFeedback) {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    }
-    
-    onPress?.(event);
-  };
+  const [isFocused, setIsFocused] = useState(false);
 
   const easing = Easing.bezier(0.2, 0.8, 0.2, 1);
+
   const handlePressIn = () => {
-    if (disabled || loading) return;
+    if (accessibility.isReduceMotionEnabled) return;
     scale.value = withTiming(tokens.Animation.press.scale, {
-      duration: tokens.Animation.duration.in,
-      easing,
-    });
-    iconOffset.value = withTiming(tokens.Animation.press.iconNudge, {
       duration: tokens.Animation.duration.in,
       easing,
     });
   };
 
   const handlePressOut = () => {
+    if (accessibility.isReduceMotionEnabled) return;
     scale.value = withTiming(1, {
       duration: tokens.Animation.duration.out,
       easing,
     });
-    iconOffset.value = withTiming(0, {
-      duration: tokens.Animation.duration.out,
-      easing,
-    });
   };
-  const buttonStyles = useMemo((): ViewStyle => {
-    const baseStyle: ViewStyle = {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'center',
-      borderRadius: tokens.BorderRadius.md,
-      ...tokens.Shadows.md,
-    };
 
-    const sizeStyles = {
-      small: {
-        paddingHorizontal: tokens.Spacing.md,
-        paddingVertical: tokens.Spacing.sm,
-        minHeight: 36,
-      },
-      medium: {
-        paddingHorizontal: tokens.Spacing.lg,
-        paddingVertical: tokens.Spacing.md,
-        minHeight: 44,
-      },
-      large: {
-        paddingHorizontal: tokens.Spacing.xl,
-        paddingVertical: tokens.Spacing.lg,
-        minHeight: 52,
-      },
-    } as const;
-
-    let variantStyles: ViewStyle = {};
-    switch (variant) {
-      case 'primary':
-        variantStyles = { backgroundColor: colors.interactive.primary };
-        break;
-      case 'secondary':
-        variantStyles = {
-          backgroundColor: colors.interactive.secondary,
-          borderWidth: 1,
-          borderColor: colors.border.medium,
-        };
-        break;
-      case 'tertiary':
-        variantStyles = { backgroundColor: 'transparent' };
-        break;
-      case 'danger':
-        variantStyles = { backgroundColor: colors.interactive.danger };
-        break;
-      case 'success':
-        variantStyles = { backgroundColor: colors.interactive.success };
-        break;
+  const handlePress = (e: any) => {
+    if (disabled || loading) return;
+    if (hapticFeedback) {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     }
+    onPress?.(e);
+  };
 
-    if (disabled) {
-      variantStyles = { ...variantStyles, opacity: 0.5 };
-    }
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
 
-    const widthStyle = fullWidth ? { width: '100%' as const } : {};
-
-    return {
-      ...baseStyle,
-      ...sizeStyles[size],
-      ...variantStyles,
-      ...widthStyle,
-    };
-  }, [variant, size, fullWidth, disabled, tokens, colors]);
-
-  const textColor = useMemo(() => {
-    if (disabled) return colors.text.tertiary;
-
-    switch (variant) {
-      case 'primary':
-      case 'danger':
-      case 'success':
-        return colors.text.inverse;
-      case 'secondary':
-        return colors.text.primary;
-      case 'tertiary':
-        return colors.interactive.primary;
-      default:
-        return colors.text.inverse;
-    }
-  }, [variant, disabled, colors]);
-
-  const textVariant = useMemo(() => {
+  const resolvedSize = useMemo(() => {
     switch (size) {
       case 'small':
-        return 'labelMedium' as const;
-      case 'medium':
-        return 'labelLarge' as const;
+      case 'sm':
+        return 'sm';
       case 'large':
-        return 'titleSmall' as const;
+      case 'lg':
+        return 'lg';
       default:
-        return 'labelLarge' as const;
+        return 'md';
     }
   }, [size]);
 
-  const gradientColors = useMemo(() => {
-    if (variant === 'primary') {
-      return [colors.interactive.primary, colors.interactive.primaryHover];
+  const sizeStyle = useMemo(() => {
+    switch (resolvedSize) {
+      case 'sm':
+        return {
+          paddingHorizontal: tokens.Spacing.md,
+          paddingVertical: tokens.Spacing.sm,
+        };
+      case 'lg':
+        return {
+          paddingHorizontal: tokens.Spacing['2xl'],
+          paddingVertical: tokens.Spacing.lg,
+        };
+      case 'md':
+      default:
+        return {
+          paddingHorizontal: tokens.Spacing.lg,
+          paddingVertical: tokens.Spacing.md,
+        };
     }
-    return [colors.interactive.primary, colors.interactive.primary];
-  }, [variant, colors]);
+  }, [resolvedSize, tokens]);
 
-  const ButtonContent = () => (
-    <>
-      {leftIcon && !loading && (
-        <React.Fragment>
-          {leftIcon}
-          <View style={{ width: tokens.Spacing.sm }} />
-        </React.Fragment>
-      )}
-      
-      {loading ? (
-        <ActivityIndicator 
-          size="small" 
-          color={textColor}
-          style={{ marginRight: leftIcon || rightIcon ? tokens.Spacing.sm : 0 }}
-        />
-      ) : (
-        <Text
-          variant={textVariant}
-          color={textColor}
-          weight="semibold"
-        >
-          {children}
-        </Text>
-      )}
-      
-      {rightIcon && !loading && (
-        <React.Fragment>
-          <View style={{ width: tokens.Spacing.sm }} />
-          <Animated.View style={iconAnimatedStyle}>{rightIcon}</Animated.View>
-        </React.Fragment>
-      )}
-    </>
-  );
+  const resolvedVariant = useMemo(() => {
+    switch (variant) {
+      case 'tertiary':
+        return 'ghost';
+      case 'danger':
+        return 'destructive';
+      case 'success':
+        return 'primary';
+      default:
+        return variant as 'primary' | 'secondary' | 'ghost' | 'destructive';
+    }
+  }, [variant]);
 
-  const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+  const { backgroundColor, borderColor, textColor } = useMemo(() => {
+    switch (resolvedVariant) {
+      case 'primary':
+        return {
+          backgroundColor: theme.interactive.primary,
+          borderColor: 'transparent',
+          textColor: theme.text.inverse,
+        };
+      case 'secondary':
+        return {
+          backgroundColor: theme.background.secondary,
+          borderColor: theme.border.light,
+          textColor: theme.text.primary,
+        };
+      case 'ghost':
+        return {
+          backgroundColor: 'transparent',
+          borderColor: 'transparent',
+          textColor: theme.interactive.primary,
+        };
+      case 'destructive':
+        return {
+          backgroundColor: theme.interactive.danger,
+          borderColor: 'transparent',
+          textColor: theme.text.inverse,
+        };
+    }
+  }, [resolvedVariant, theme]);
 
-  // Render with gradient if enabled and primary variant
-  if (gradient && variant === 'primary' && !disabled) {
-    return (
-      <AnimatedPressable
-        style={[buttonStyles, animatedStyle, style]}
+  const baseStyle: ViewStyle = {
+    borderRadius: tokens.BorderRadius.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: borderColor === 'transparent' ? 0 : StyleSheet.hairlineWidth,
+    backgroundColor,
+    borderColor,
+    opacity: disabled ? 0.5 : 1,
+  };
+
+  const focusStyle = isFocused
+    ? { borderWidth: 2, borderColor: theme.border.brand }
+    : {};
+
+  const widthStyle = fullWidth ? { alignSelf: 'stretch' } : {};
+
+  return (
+    <Animated.View style={[widthStyle, animatedStyle]}>
+      <Pressable
         onPress={handlePress}
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
         disabled={disabled || loading}
-        accessibilityLabel={getAccessibilityLabel()}
-        accessibilityHint={getAccessibilityHint()}
-        accessibilityRole={accessibilityRole}
-        accessibilityState={{
-          disabled: disabled || loading,
-          busy: loading,
-        }}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={accessibilityHint}
         testID={testID}
+        style={[baseStyle, sizeStyle, focusStyle, style]}
         {...props}
       >
-        <LinearGradient
-          colors={gradientColors as [string, string, ...string[]]}
-          start={{ x: 0, y: 0 }}
-          end={{ x: 1, y: 1 }}
-          style={[StyleSheet.absoluteFill, { borderRadius: tokens.BorderRadius.md }]}
-        />
-        <ButtonContent />
-      </AnimatedPressable>
-    );
-  }
-
-  // Regular button
-  return (
-    <AnimatedPressable
-      style={[buttonStyles, animatedStyle, style]}
-      onPress={handlePress}
-      onPressIn={handlePressIn}
-      onPressOut={handlePressOut}
-      disabled={disabled || loading}
-      accessibilityLabel={getAccessibilityLabel()}
-      accessibilityHint={getAccessibilityHint()}
-      accessibilityRole={accessibilityRole}
-      accessibilityState={{
-        disabled: disabled || loading,
-        busy: loading,
-      }}
-      testID={testID}
-      {...props}
-    >
-      <ButtonContent />
-    </AnimatedPressable>
+        {leftIcon && !loading && (
+          <View style={{ marginRight: tokens.Spacing.sm }}>{leftIcon}</View>
+        )}
+        {loading ? (
+          <ActivityIndicator color={textColor} />
+        ) : (
+          <Text variant="labelLarge" weight="semibold" color={textColor}>
+            {children}
+          </Text>
+        )}
+        {rightIcon && !loading && (
+          <View style={{ marginLeft: tokens.Spacing.sm }}>{rightIcon}</View>
+        )}
+      </Pressable>
+    </Animated.View>
   );
 };
 

--- a/apps/mobile/src/components/ui/Card.tsx
+++ b/apps/mobile/src/components/ui/Card.tsx
@@ -1,9 +1,3 @@
-/**
- * Modern Card Component
- * Premium card with 2025 design standards
- * Subtle shadows and interaction states
- */
-
 import * as Haptics from 'expo-haptics';
 import React from 'react';
 import {
@@ -22,21 +16,26 @@ import Animated, {
 } from 'react-native-reanimated';
 
 import Text from './Text';
-import { useTheme, useTokens } from '../../design-system/ThemeProvider';
+import {
+  useTheme,
+  useTokens,
+  getGlassBackground,
+  getGlassBorder,
+} from '../../design-system/ThemeProvider';
 
 // ============================================================================
 // TYPES
 // ============================================================================
 
-type CardVariant = 'elevated' | 'outlined' | 'filled';
+type CardVariant = 'elevated' | 'outlined' | 'filled' | 'glass';
 
 interface BaseCardProps {
   variant?: CardVariant;
   interactive?: boolean;
   hapticFeedback?: boolean;
   style?: ViewStyle;
+  contentStyle?: ViewStyle;
   children: React.ReactNode;
-  // Accessibility props
   accessibilityLabel?: string;
   accessibilityHint?: string;
   accessibilityRole?: 'none' | 'button' | 'link' | 'text' | 'summary';
@@ -65,6 +64,7 @@ export const Card: React.FC<CardProps> = ({
   interactive = false,
   hapticFeedback = true,
   style,
+  contentStyle,
   children,
   accessibilityLabel,
   accessibilityHint,
@@ -77,22 +77,17 @@ export const Card: React.FC<CardProps> = ({
   const scale = useSharedValue(1);
 
   // Animation for interactive cards
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      transform: [{ scale: scale.value }],
-    };
-  });
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
 
-  // Handle press interactions (non-bouncy, premium feel)
   const handlePressIn = () => {
     if (!interactive) return;
-
     const easing = Easing.bezier(0.2, 0.8, 0.2, 1);
     scale.value = withTiming(tokens.Animation.press.scale, {
       duration: tokens.Animation.duration.in,
       easing,
     });
-
     if (hapticFeedback) {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     }
@@ -100,7 +95,6 @@ export const Card: React.FC<CardProps> = ({
 
   const handlePressOut = () => {
     if (!interactive) return;
-
     const easing = Easing.bezier(0.2, 0.8, 0.2, 1);
     scale.value = withTiming(1, {
       duration: tokens.Animation.duration.out,
@@ -109,12 +103,10 @@ export const Card: React.FC<CardProps> = ({
   };
 
   const getOuterStyle = (): ViewStyle => {
-    const base: ViewStyle = {
-      borderRadius: tokens.BorderRadius.lg,
-    };
-
+    const base: ViewStyle = { borderRadius: tokens.BorderRadius.lg };
     switch (variant) {
       case 'elevated':
+      case 'glass':
         return { ...base, ...tokens.Shadows.lg };
       case 'filled':
       case 'outlined':
@@ -125,12 +117,12 @@ export const Card: React.FC<CardProps> = ({
 
   const getInnerStyle = (): ViewStyle => {
     const base: ViewStyle = {
-      backgroundColor: theme.background.primary,
       borderRadius: tokens.BorderRadius.lg,
       padding: tokens.Spacing.lg,
       overflow: 'hidden',
       borderWidth: StyleSheet.hairlineWidth,
       borderColor: theme.border.light,
+      backgroundColor: theme.background.primary,
     };
 
     switch (variant) {
@@ -138,6 +130,12 @@ export const Card: React.FC<CardProps> = ({
         return { ...base, backgroundColor: theme.background.elevated };
       case 'filled':
         return { ...base, backgroundColor: theme.background.secondary };
+      case 'glass':
+        return {
+          ...base,
+          backgroundColor: getGlassBackground(theme, 'neutral', 'regular'),
+          borderColor: getGlassBorder(theme, 'regular'),
+        };
       case 'outlined':
       default:
         return base;
@@ -145,21 +143,18 @@ export const Card: React.FC<CardProps> = ({
   };
 
   const outerStyle = getOuterStyle();
-  const innerStyle = getInnerStyle();
+  const innerBaseStyle = getInnerStyle();
+  const innerStyles = [innerBaseStyle, contentStyle];
 
-  // Accessibility
   const getAccessibilityProps = () => {
     const defaultRole = interactive ? 'button' : 'text';
     const role = accessibilityRole ?? defaultRole;
-
     const defaultLabel = interactive
-      ? (accessibilityLabel ?? 'Interactive card')
+      ? accessibilityLabel ?? 'Interactive card'
       : accessibilityLabel;
-
     const defaultHint = interactive
-      ? (accessibilityHint ?? 'Double tap to interact with this card')
+      ? accessibilityHint ?? 'Double tap to interact with this card'
       : accessibilityHint;
-
     return {
       accessible: true,
       accessibilityLabel: defaultLabel,
@@ -169,15 +164,13 @@ export const Card: React.FC<CardProps> = ({
     };
   };
 
-  // Render interactive card
   if (interactive) {
     const { onPress, onPressIn, onPressOut, ...pressableProps } = props as InteractiveCardProps;
     const accessibilityProps = getAccessibilityProps();
-
     return (
       <Animated.View style={[outerStyle, animatedStyle, style]}>
         <Pressable
-          style={innerStyle}
+          style={innerStyles}
           onPress={onPress}
           onPressIn={(e: GestureResponderEvent) => {
             handlePressIn();
@@ -196,11 +189,10 @@ export const Card: React.FC<CardProps> = ({
     );
   }
 
-  // Render static card
   const accessibilityProps = getAccessibilityProps();
   return (
     <Animated.View style={[outerStyle, style]} {...accessibilityProps}>
-      <View style={innerStyle}>{children}</View>
+      <View style={innerStyles}>{children}</View>
     </Animated.View>
   );
 };
@@ -218,7 +210,6 @@ interface CardHeaderProps {
 
 export const CardHeader: React.FC<CardHeaderProps> = ({ title, subtitle, action, style }) => {
   const tokens = useTokens();
-
   return (
     <View
       style={[
@@ -276,7 +267,6 @@ interface CardFooterProps {
 
 export const CardFooter: React.FC<CardFooterProps> = ({ children, style }) => {
   const tokens = useTokens();
-
   return (
     <View
       style={[


### PR DESCRIPTION
## Summary
- swap ad-hoc UI in Expenses, Groceries, and Profile screens for shared Button, Card, and Badge primitives
- add glass variant and contentStyle to Card and streamline Button variants/sizes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b534289a20832181c150454e7faae5