### PR TITLE
feat: improve mobile a11y helpers and tests

### DIFF
--- a/apps/mobile/__tests__/a11y/button.a11y.test.tsx
+++ b/apps/mobile/__tests__/a11y/button.a11y.test.tsx
@@ -4,8 +4,7 @@ import Button from '@/components/ui/Button';
 import Text from '@/components/ui/Text';
 
 test('icon-only buttons expose accessibilityLabel', () => {
-  render(
-    <Button accessibilityLabel="Settings" leftIcon={<Text>icon</Text>} />,
-  );
+  // @ts-expect-error - children are intentionally omitted for icon-only button
+  render(<Button accessibilityLabel="Settings" leftIcon={<Text>icon</Text>} />);
   expect(screen.getByRole('button', { name: 'Settings' })).toBeTruthy();
 });

--- a/apps/mobile/__tests__/a11y/button.a11y.test.tsx
+++ b/apps/mobile/__tests__/a11y/button.a11y.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '../test-utils';
+import Button from '@/components/ui/Button';
+import Text from '@/components/ui/Text';
+
+test('icon-only buttons expose accessibilityLabel', () => {
+  render(
+    <Button accessibilityLabel="Settings" leftIcon={<Text>icon</Text>} />,
+  );
+  expect(screen.getByRole('button', { name: 'Settings' })).toBeTruthy();
+});

--- a/apps/mobile/__tests__/a11y/listitem.a11y.test.tsx
+++ b/apps/mobile/__tests__/a11y/listitem.a11y.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render, screen } from '../test-utils';
+import ListItem from '@/components/ui/ListItem';
+
+test('ListItem pressable is accessible with role button', () => {
+  render(<ListItem title="Item" onPress={() => {}} />);
+  expect(screen.getByRole('button', { name: 'Item' })).toBeTruthy();
+});

--- a/apps/mobile/__tests__/a11y/reduced-motion.a11y.test.tsx
+++ b/apps/mobile/__tests__/a11y/reduced-motion.a11y.test.tsx
@@ -30,14 +30,10 @@ jest.mock('@/design-system/ThemeProvider', () => {
 });
 
 test('no scale animation when reduce motion enabled', () => {
-  const { getByRole } = render(
-    <Button accessibilityLabel="ok">OK</Button>,
-  );
+  const { getByRole } = render(<Button accessibilityLabel="ok">OK</Button>);
   const button = getByRole('button');
   const parent = button.parent as any;
-  const styleArray = Array.isArray(parent.props.style)
-    ? parent.props.style
-    : [parent.props.style];
+  const styleArray = Array.isArray(parent.props.style) ? parent.props.style : [parent.props.style];
   const transformStyle = styleArray.find((s: any) => s && s.transform);
   expect(transformStyle?.transform ?? [{ scale: 1 }]).toEqual([{ scale: 1 }]);
 });

--- a/apps/mobile/__tests__/a11y/reduced-motion.a11y.test.tsx
+++ b/apps/mobile/__tests__/a11y/reduced-motion.a11y.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import Button from '@/components/ui/Button';
+
+jest.mock('@/design-system/ThemeProvider', () => {
+  const tokens = require('@/design-system/tokens').default;
+  const { LightTheme } = require('@/design-system/tokens');
+  return {
+    __esModule: true,
+    useTokens: () => tokens,
+    useTheme: () => ({
+      theme: LightTheme,
+      config: { colorScheme: 'light', contrast: 'normal', followSystemContrast: true },
+      isDark: false,
+      isHighContrast: false,
+      toggleTheme: jest.fn(),
+      toggleContrast: jest.fn(),
+      setColorScheme: jest.fn(),
+      setContrastMode: jest.fn(),
+      tokens,
+      accessibility: {
+        isScreenReaderEnabled: false,
+        isReduceMotionEnabled: true,
+        isHighContrastEnabled: false,
+        preferredContentSizeCategory: 'medium',
+      },
+    }),
+    useColors: () => LightTheme,
+  };
+});
+
+test('no scale animation when reduce motion enabled', () => {
+  const { getByRole } = render(
+    <Button accessibilityLabel="ok">OK</Button>,
+  );
+  const button = getByRole('button');
+  const parent = button.parent as any;
+  const styleArray = Array.isArray(parent.props.style)
+    ? parent.props.style
+    : [parent.props.style];
+  const transformStyle = styleArray.find((s: any) => s && s.transform);
+  expect(transformStyle?.transform ?? [{ scale: 1 }]).toEqual([{ scale: 1 }]);
+});

--- a/apps/mobile/__tests__/a11y/segmentedcontrol.a11y.test.tsx
+++ b/apps/mobile/__tests__/a11y/segmentedcontrol.a11y.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '../test-utils';
+import SegmentedControl from '@/components/ui/SegmentedControl';
+
+test('SegmentedControl renders tabs with selected state', () => {
+  const segments = [
+    { key: 'one', label: 'One' },
+    { key: 'two', label: 'Two' },
+  ];
+  render(
+    <SegmentedControl segments={segments} value="two" onChange={() => {}} />,
+  );
+  const selected = screen.getByRole('tab', { name: 'Two' });
+  expect(selected).toHaveAccessibilityState({ selected: true });
+});

--- a/apps/mobile/__tests__/a11y/segmentedcontrol.a11y.test.tsx
+++ b/apps/mobile/__tests__/a11y/segmentedcontrol.a11y.test.tsx
@@ -7,9 +7,8 @@ test('SegmentedControl renders tabs with selected state', () => {
     { key: 'one', label: 'One' },
     { key: 'two', label: 'Two' },
   ];
-  render(
-    <SegmentedControl segments={segments} value="two" onChange={() => {}} />,
-  );
+  render(<SegmentedControl segments={segments} value="two" onChange={() => {}} />);
   const selected = screen.getByRole('tab', { name: 'Two' });
+  // @ts-expect-error - matcher provided by jest-native typings
   expect(selected).toHaveAccessibilityState({ selected: true });
 });

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -6,16 +6,19 @@ jest.mock('react-native-reanimated', () => ({
   default: {
     createAnimatedComponent: (Component: any) => Component,
     addWhitelistedUIProps: () => {},
+    View: require('react-native').View,
   },
   createAnimatedComponent: (Component: any) => Component,
   addWhitelistedUIProps: () => {},
   View: require('react-native').View,
-  useSharedValue: () => ({ value: 0 }),
+  useSharedValue: () => ({ value: 1 }),
   withTiming: (value: any) => value,
+  useAnimatedStyle: (fn: any) => fn(),
   Easing: {
     linear: (t: any) => t,
     out: (fn: any) => fn,
     inOut: (fn: any) => fn,
+    bezier: () => (t: any) => t,
   },
 }));
 (global as any).ReanimatedDataMock = { now: () => Date.now() };

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -12,6 +12,7 @@ import { usePressFeedback } from '../animation/usePressFeedback';
 
 import Text from './Text';
 import { useTheme, useTokens } from '../../design-system/ThemeProvider';
+import { ensureMinTouchTarget, asButtonProps } from '@/utils/a11y';
 
 // ============================================================================
 // TYPES
@@ -186,11 +187,16 @@ export const Button: React.FC<ButtonProps> = ({
         onFocus={() => setIsFocused(true)}
         onBlur={() => setIsFocused(false)}
         disabled={disabled || loading}
-        accessibilityRole="button"
+        {...asButtonProps(disabled || loading)}
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
         testID={testID}
-        style={[baseStyle, sizeStyle, focusStyle, style]}
+        style={ensureMinTouchTarget([
+          baseStyle,
+          sizeStyle,
+          focusStyle,
+          style,
+        ])}
         {...rest}
       >
         {leftIcon && !loading && <View style={{ marginRight: tokens.Spacing.sm }}>{leftIcon}</View>}

--- a/apps/mobile/src/components/ui/Button.tsx
+++ b/apps/mobile/src/components/ui/Button.tsx
@@ -191,12 +191,7 @@ export const Button: React.FC<ButtonProps> = ({
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={accessibilityHint}
         testID={testID}
-        style={ensureMinTouchTarget([
-          baseStyle,
-          sizeStyle,
-          focusStyle,
-          style,
-        ])}
+        style={ensureMinTouchTarget([baseStyle, sizeStyle, focusStyle, style])}
         {...rest}
       >
         {leftIcon && !loading && <View style={{ marginRight: tokens.Spacing.sm }}>{leftIcon}</View>}

--- a/apps/mobile/src/components/ui/ListItem.tsx
+++ b/apps/mobile/src/components/ui/ListItem.tsx
@@ -8,6 +8,7 @@ import GlassToggle from './GlassToggle';
 import Icon from './Icon';
 import Text from './Text';
 import { useTheme, useTokens } from '../../design-system/ThemeProvider';
+import { ensureMinTouchTarget, asButtonProps } from '@/utils/a11y';
 
 // ============================================================================
 // TYPES
@@ -183,8 +184,8 @@ export const ListItem: React.FC<ListItemProps> = ({
         onPress={onPress}
         onPressIn={onPressIn}
         onPressOut={onPressOut}
-        style={[containerStyle, style, animatedStyle]}
-        accessibilityRole="button"
+        style={ensureMinTouchTarget([containerStyle, style, animatedStyle])}
+        {...asButtonProps()}
         accessibilityLabel={accessibilityLabel ?? title}
         accessibilityHint={accessibilityHint}
         testID={testID}

--- a/apps/mobile/src/components/ui/SegmentedControl.tsx
+++ b/apps/mobile/src/components/ui/SegmentedControl.tsx
@@ -4,6 +4,7 @@ import Animated from 'react-native-reanimated';
 import Text from './Text';
 import { usePressFeedback } from '../animation/usePressFeedback';
 import { useTheme, useTokens, withOpacity } from '../../design-system/ThemeProvider';
+import { ensureMinTouchTarget, asTabProps } from '@/utils/a11y';
 
 interface Segment {
   key: string;
@@ -45,16 +46,17 @@ const SegmentedTabButton = ({
         onPress={onPress}
         onPressIn={onPressIn}
         onPressOut={onPressOut}
-        accessibilityRole="button"
-        accessibilityState={{ selected: active }}
+        {...asTabProps(active)}
         accessibilityLabel={label}
-        style={{
+        style={ensureMinTouchTarget({
           paddingVertical: tokens.Spacing.sm,
           alignItems: 'center',
           justifyContent: 'center',
           borderRadius: tokens.BorderRadius.lg,
-          backgroundColor: active ? withOpacity(theme.interactive.primary, 0.08) : 'transparent',
-        }}
+          backgroundColor: active
+            ? withOpacity(theme.interactive.primary, 0.08)
+            : 'transparent',
+        })}
       >
         <Text
           variant="labelLarge"

--- a/apps/mobile/src/components/ui/SegmentedControl.tsx
+++ b/apps/mobile/src/components/ui/SegmentedControl.tsx
@@ -53,9 +53,7 @@ const SegmentedTabButton = ({
           alignItems: 'center',
           justifyContent: 'center',
           borderRadius: tokens.BorderRadius.lg,
-          backgroundColor: active
-            ? withOpacity(theme.interactive.primary, 0.08)
-            : 'transparent',
+          backgroundColor: active ? withOpacity(theme.interactive.primary, 0.08) : 'transparent',
         })}
       >
         <Text

--- a/apps/mobile/src/utils/a11y.ts
+++ b/apps/mobile/src/utils/a11y.ts
@@ -1,0 +1,43 @@
+import { StyleProp, ViewStyle } from 'react-native';
+
+/**
+ * Ensure minimum touch target of 44x44pt without forcing layout changes.
+ * Returns a style array combining the provided style with min dimensions.
+ */
+export const ensureMinTouchTarget = (
+  style?: StyleProp<ViewStyle>,
+): StyleProp<ViewStyle> => [{ minWidth: 44, minHeight: 44 }, style];
+
+/**
+ * Accessibility props for Pressable acting as a button.
+ */
+export const asButtonProps = (disabled = false) => ({
+  accessible: true,
+  accessibilityRole: 'button' as const,
+  accessibilityState: { disabled },
+});
+
+/**
+ * Accessibility props for headings.
+ */
+export const asHeaderProps = (level?: number) => ({
+  accessible: true,
+  accessibilityRole: 'header' as const,
+  ...(level !== undefined ? { accessibilityLevel: level } : {}),
+});
+
+/**
+ * Accessibility props for tabs.
+ */
+export const asTabProps = (selected = false) => ({
+  accessible: true,
+  accessibilityRole: 'tab' as const,
+  accessibilityState: { selected },
+});
+
+export default {
+  ensureMinTouchTarget,
+  asButtonProps,
+  asHeaderProps,
+  asTabProps,
+};

--- a/apps/mobile/src/utils/a11y.ts
+++ b/apps/mobile/src/utils/a11y.ts
@@ -4,9 +4,10 @@ import { StyleProp, ViewStyle } from 'react-native';
  * Ensure minimum touch target of 44x44pt without forcing layout changes.
  * Returns a style array combining the provided style with min dimensions.
  */
-export const ensureMinTouchTarget = (
-  style?: StyleProp<ViewStyle>,
-): StyleProp<ViewStyle> => [{ minWidth: 44, minHeight: 44 }, style];
+export const ensureMinTouchTarget = (style?: StyleProp<ViewStyle>): StyleProp<ViewStyle> => [
+  { minWidth: 44, minHeight: 44 },
+  style,
+];
 
 /**
  * Accessibility props for Pressable acting as a button.


### PR DESCRIPTION
## Summary
- add a11y utility helpers and touch target enforcement
- wire Button, ListItem, SegmentedControl to new a11y helpers
- cover common accessibility scenarios with new tests

## Testing
- `npx jest --runInBand __tests__/a11y/button.a11y.test.tsx __tests__/a11y/listitem.a11y.test.tsx __tests__/a11y/segmentedcontrol.a11y.test.tsx __tests__/a11y/reduced-motion.a11y.test.tsx`
- `npx jest --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68b727f9bf68832183d70416666e57e2