### PR TITLE
feat(mobile): guard expo-blur import and check dependencies

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -13,3 +13,4 @@ Install `react-native-svg` using `npx expo install react-native-svg` to ensure t
 - Lockfile sync: prefer `npm ci --no-audit --legacy-peer-deps`. If the lockfile drifts, run `npm install --no-audit --legacy-peer-deps` once and commit `package-lock.json`.
 - Peer dependencies are pinned; avoid bumping versions in CI.
 - Gated logs: set `EXPO_PUBLIC_DEBUG=deeplink,auth` to enable debug channels.
+- SafeBlur: uses a fallback `<View>` in dev when `expo-blur` is missing, but throws in production/CI. Install with `npx expo install expo-blur` and keep lockfile synced with `npm ci --no-audit --legacy-peer-deps`.

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -39,7 +39,11 @@ require('react-native').AccessibilityInfo = mockAccessibilityInfo;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 jest.mock('expo-linear-gradient', () => require('react-native').View);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-jest.mock('expo-blur', () => ({ BlurView: require('react-native').View }));
+jest.mock('@/components/ui/SafeBlur', () => ({
+  __esModule: true,
+  BlurView: require('react-native').View,
+  default: require('react-native').View,
+}));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,10 +16,12 @@
     "test": "jest",
     "test:ci": "jest --runInBand",
     "orphans": "node tools/find-orphans.js",
-    "ci:check": "npm run format:check && npm run lint:colors && npm run typecheck && npm test && npm run orphans",
+    "doctor:deps": "node tools/deps-doctor.js",
+    "ci:check": "npm run doctor:deps && npm run format:check && npm run lint:colors && npm run typecheck && npm test && npm run orphans",
     "codemod:colors:dry": "jscodeshift -d -p -t ../../tools/codemods/replace-hardcoded-colors.js src",
     "codemod:colors": "jscodeshift -t ../../tools/codemods/replace-hardcoded-colors.js src",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "prestart": "node tools/deps-doctor.js || true"
   },
   "dependencies": {
     "@expo-google-fonts/dev": "^0.4.7",

--- a/apps/mobile/src/components/ui/GlassView.tsx
+++ b/apps/mobile/src/components/ui/GlassView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useMemo } from 'react';
 import { View, ViewStyle, Platform, StyleSheet, StyleProp, AccessibilityRole } from 'react-native';
-import { BlurView } from 'expo-blur';
+import { BlurView } from '@/components/ui/SafeBlur';
 import { useColors, useTokens, withOpacity } from '../../design-system/ThemeProvider';
 
 // ============================================================================

--- a/apps/mobile/src/components/ui/SafeBlur.tsx
+++ b/apps/mobile/src/components/ui/SafeBlur.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View } from 'react-native';
+
+let RealBlur: React.ComponentType<any> | null = null;
+
+try {
+  require.resolve('expo-blur');
+  RealBlur = require('expo-blur/build/BlurView').BlurView;
+} catch {}
+
+function MissingModuleError() {
+  return new Error("expo-blur is missing. Install it with 'npx expo install expo-blur'.");
+}
+
+export const BlurView: React.FC<any> = (props) => {
+  if (RealBlur) {
+    const Comp = RealBlur as React.ComponentType<any>;
+    return <Comp {...props} />;
+  }
+  if (__DEV__) {
+    console.warn('expo-blur not installed; falling back to <View>.');
+    return <View {...props} />;
+  }
+  throw MissingModuleError();
+};
+
+export default BlurView;

--- a/apps/mobile/src/components/ui/ScreenBackground.tsx
+++ b/apps/mobile/src/components/ui/ScreenBackground.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleSheet, SafeAreaView } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { BlurView } from 'expo-blur';
+import { BlurView } from '@/components/ui/SafeBlur';
 import Svg, { Path } from 'react-native-svg';
 import { useColors, useTheme, withOpacity } from '@/design-system/ThemeProvider';
 

--- a/apps/mobile/tools/deps-doctor.js
+++ b/apps/mobile/tools/deps-doctor.js
@@ -1,0 +1,31 @@
+const modules = [
+  'expo-blur',
+  'expo-linear-gradient',
+  'react-native-svg',
+  'react-native-reanimated',
+  '@react-navigation/native',
+];
+
+const missing = [];
+
+for (const mod of modules) {
+  try {
+    require.resolve(mod);
+    if (mod === 'expo-blur') {
+      require.resolve('expo-blur/build/BlurView');
+    }
+  } catch {
+    missing.push(mod);
+  }
+}
+
+if (missing.length) {
+  const fix = `npx expo install ${missing.join(' ')}`;
+  const message = `Missing required dependencies: ${missing.join(', ')}\nFix: ${fix}`;
+  if (process.env.CI || process.env.NODE_ENV === 'production') {
+    console.error(message);
+    process.exit(1);
+  } else {
+    console.warn(message);
+  }
+}


### PR DESCRIPTION
## Summary
- wrap expo-blur in SafeBlur component with dev fallback and production error
- enforce dependency checks with deps doctor and hook into CI/start
- mock SafeBlur for tests and document install steps

## Testing
- `npm run doctor:deps`
- `npm run format:check`
- `npm run lint:colors`
- `npm run typecheck`
- `npm test`
- `npm run ci:check`


------
https://chatgpt.com/codex/tasks/task_e_68b75a615a308321b353cbf236a5d632