### PR TITLE
fix: stabilize SafeBlur expo-blur loading

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -13,4 +13,4 @@ Install `react-native-svg` using `npx expo install react-native-svg` to ensure t
 - Lockfile sync: prefer `npm ci --no-audit --legacy-peer-deps`. If the lockfile drifts, run `npm install --no-audit --legacy-peer-deps` once and commit `package-lock.json`.
 - Peer dependencies are pinned; avoid bumping versions in CI.
 - Gated logs: set `EXPO_PUBLIC_DEBUG=deeplink,auth` to enable debug channels.
-- SafeBlur: uses a fallback `<View>` in dev when `expo-blur` is missing, but throws in production/CI. Install with `npx expo install expo-blur` and keep lockfile synced with `npm ci --no-audit --legacy-peer-deps`.
+- Blur is optional at runtime via SafeBlur; if `expo-blur` is missing in dev or test, we render a plain `View`. Do not add `expo-blur` to `app.json` plugins.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -40,7 +40,6 @@
         }
       ],
       "expo-audio",
-      "expo-blur",
       [
         "expo-build-properties",
         {

--- a/apps/mobile/eslint.config.js
+++ b/apps/mobile/eslint.config.js
@@ -49,6 +49,10 @@ export default [
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
       'local/no-hardcoded-colors': 'error',
+      'no-restricted-imports': [
+        'error',
+        { patterns: ['**/node_modules/**/build/*', '**/build/*'] },
+      ],
     },
   },
   {

--- a/apps/mobile/jest.setup.ts
+++ b/apps/mobile/jest.setup.ts
@@ -39,11 +39,7 @@ require('react-native').AccessibilityInfo = mockAccessibilityInfo;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 jest.mock('expo-linear-gradient', () => require('react-native').View);
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-jest.mock('@/components/ui/SafeBlur', () => ({
-  __esModule: true,
-  BlurView: require('react-native').View,
-  default: require('react-native').View,
-}));
+jest.mock('expo-blur', () => ({ BlurView: require('react-native').View }));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock'),

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -17,6 +17,7 @@
     "test:ci": "jest --runInBand",
     "orphans": "node tools/find-orphans.js",
     "doctor:deps": "node tools/deps-doctor.js",
+    "doctor": "expo doctor",
     "ci:check": "npm run doctor:deps && npm run format:check && npm run lint:colors && npm run typecheck && npm test && npm run orphans",
     "codemod:colors:dry": "jscodeshift -d -p -t ../../tools/codemods/replace-hardcoded-colors.js src",
     "codemod:colors": "jscodeshift -t ../../tools/codemods/replace-hardcoded-colors.js src",

--- a/apps/mobile/src/components/ui/GlassView.tsx
+++ b/apps/mobile/src/components/ui/GlassView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useMemo } from 'react';
 import { View, ViewStyle, Platform, StyleSheet, StyleProp, AccessibilityRole } from 'react-native';
-import { BlurView } from '@/components/ui/SafeBlur';
+import SafeBlur from '@/components/ui/SafeBlur';
 import { useColors, useTokens, withOpacity } from '../../design-system/ThemeProvider';
 
 // ============================================================================
@@ -191,7 +191,7 @@ export const GlassView: React.FC<GlassViewProps> = ({
   // Fallback background for web and older platforms
   const fallbackBackground = withOpacity(isDark ? '#000000' : '#FFFFFF', getOpacity);
 
-  // Use BlurView on supported platforms, fallback to semi-transparent View
+  // Use SafeBlur on supported platforms, fallback to semi-transparent View
   if (Platform.OS === 'ios' || Platform.OS === 'android') {
     return (
       <View
@@ -201,9 +201,9 @@ export const GlassView: React.FC<GlassViewProps> = ({
         accessibilityRole={accessibilityRole}
         testID={testID}
       >
-        <BlurView intensity={getBlurIntensity} tint={tint as any} style={styles.blurView}>
+        <SafeBlur intensity={getBlurIntensity} tint={tint as any} style={styles.blurView}>
           {children}
-        </BlurView>
+        </SafeBlur>
       </View>
     );
   }

--- a/apps/mobile/src/components/ui/SafeBlur.tsx
+++ b/apps/mobile/src/components/ui/SafeBlur.tsx
@@ -1,27 +1,20 @@
 import React from 'react';
 import { View } from 'react-native';
 
-let RealBlur: React.ComponentType<any> | null = null;
+// Default to View; swap to BlurView if available
+let Impl: React.ComponentType<any> = View;
 
 try {
-  require.resolve('expo-blur');
-  RealBlur = require('expo-blur/build/BlurView').BlurView;
-} catch {}
-
-function MissingModuleError() {
-  return new Error("expo-blur is missing. Install it with 'npx expo install expo-blur'.");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require('expo-blur');
+  Impl = mod?.BlurView ?? View;
+} catch {
+  if (__DEV__ || process.env.JEST_WORKER_ID) {
+    console.warn('expo-blur not installed; falling back to <View>.');
+  }
 }
 
-export const BlurView: React.FC<any> = (props) => {
-  if (RealBlur) {
-    const Comp = RealBlur as React.ComponentType<any>;
-    return <Comp {...props} />;
-  }
-  if (__DEV__) {
-    console.warn('expo-blur not installed; falling back to <View>.');
-    return <View {...props} />;
-  }
-  throw MissingModuleError();
-};
+const SafeBlur: React.FC<any> = (props) => <Impl {...props} />;
 
-export default BlurView;
+export const BlurView = SafeBlur;
+export default SafeBlur;

--- a/apps/mobile/src/components/ui/ScreenBackground.tsx
+++ b/apps/mobile/src/components/ui/ScreenBackground.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, StyleSheet, SafeAreaView } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
-import { BlurView } from '@/components/ui/SafeBlur';
+import SafeBlur from '@/components/ui/SafeBlur';
 import Svg, { Path } from 'react-native-svg';
 import { useColors, useTheme, withOpacity } from '@/design-system/ThemeProvider';
 
@@ -129,7 +129,7 @@ export const ScreenBackground: React.FC<ScreenBackgroundProps> = ({
       );
       if (shape.blur) {
         return (
-          <BlurView
+          <SafeBlur
             key={idx}
             intensity={shape.blur}
             style={{
@@ -141,7 +141,7 @@ export const ScreenBackground: React.FC<ScreenBackgroundProps> = ({
             }}
           >
             {base}
-          </BlurView>
+          </SafeBlur>
         );
       }
       return base;

--- a/apps/mobile/tools/deps-doctor.js
+++ b/apps/mobile/tools/deps-doctor.js
@@ -11,9 +11,6 @@ const missing = [];
 for (const mod of modules) {
   try {
     require.resolve(mod);
-    if (mod === 'expo-blur') {
-      require.resolve('expo-blur/build/BlurView');
-    }
   } catch {
     missing.push(mod);
   }


### PR DESCRIPTION
## Summary
- update SafeBlur to require `expo-blur` from top-level and gracefully fallback
- remove brittle `expo-blur` config/mocks and enforce no deep imports
- document optional blur and add `expo doctor` script

## Testing
- `npm run format:check`
- `npm run lint:colors`
- `npm test`
- `npm run doctor` *(fails: expo doctor not supported in local CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b6a6696483218a94146994cad2fc