### PR TITLE
fix: add latest poll hook and integrate into Home

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.jsx
+++ b/apps/mobile/src/app/(tabs)/index.jsx
@@ -196,7 +196,11 @@ export default function HomeScreen() {
             accessibilityRole="button"
             accessibilityLabel="View poll results"
           >
-            <Text variant="titleMedium" weight="semibold" style={{ marginBottom: tokens.Spacing.xs }}>
+            <Text
+              variant="titleMedium"
+              weight="semibold"
+              style={{ marginBottom: tokens.Spacing.xs }}
+            >
               {activePoll.question}
             </Text>
             <Text variant="bodySmall" color="secondary">

--- a/apps/mobile/src/app/(tabs)/index.jsx
+++ b/apps/mobile/src/app/(tabs)/index.jsx
@@ -66,7 +66,8 @@ export default function HomeScreen() {
   const { theme } = useTheme();
   const tokens = useTokens();
   const router = useRouter();
-  const { data: activePoll } = useLatestPoll();
+  const groupId = process.env.EXPO_PUBLIC_PROJECT_GROUP_ID;
+  const { data: activePoll } = useLatestPoll(groupId);
   const stops = usePalette('brandWatercolor');
   useSceneBackground({
     key: 'home',
@@ -181,26 +182,28 @@ export default function HomeScreen() {
           </View>
         </View>
 
-        <Pressable
-          onPress={() => router.push(activePoll ? `/polls/${activePoll.id}` : '/polls/create')}
-          style={{
-            backgroundColor: withOpacity(theme.interactive.primary, 0.05),
-            borderColor: theme.border.light,
-            borderWidth: StyleSheet.hairlineWidth,
-            borderRadius: tokens.BorderRadius.lg,
-            padding: tokens.Spacing.lg,
-            marginBottom: tokens.Spacing.xl,
-          }}
-          accessibilityRole="button"
-          accessibilityLabel={activePoll ? 'View poll results' : 'Create a poll'}
-        >
-          <Text variant="titleMedium" weight="semibold" style={{ marginBottom: tokens.Spacing.xs }}>
-            {activePoll ? activePoll.question : 'Start a poll with your roommates'}
-          </Text>
-          <Text variant="bodySmall" color="secondary">
-            {activePoll ? 'Tap to view results' : 'Tap to create a poll'}
-          </Text>
-        </Pressable>
+        {!!activePoll && (
+          <Pressable
+            onPress={() => router.push(`/polls/${activePoll.id}`)}
+            style={{
+              backgroundColor: withOpacity(theme.interactive.primary, 0.05),
+              borderColor: theme.border.light,
+              borderWidth: StyleSheet.hairlineWidth,
+              borderRadius: tokens.BorderRadius.lg,
+              padding: tokens.Spacing.lg,
+              marginBottom: tokens.Spacing.xl,
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="View poll results"
+          >
+            <Text variant="titleMedium" weight="semibold" style={{ marginBottom: tokens.Spacing.xs }}>
+              {activePoll.question}
+            </Text>
+            <Text variant="bodySmall" color="secondary">
+              Tap to view results
+            </Text>
+          </Pressable>
+        )}
 
         {/* Quick Navigation Grid */}
         <View style={{ marginBottom: tokens.Spacing.xl }}>

--- a/apps/mobile/src/features/polls/hooks.ts
+++ b/apps/mobile/src/features/polls/hooks.ts
@@ -20,6 +20,26 @@ export interface PollVote {
   vote: boolean;
 }
 
+export function useLatestPoll(groupId?: string) {
+  return useQuery<Poll | null>({
+    queryKey: ['polls', 'latest', groupId ?? 'none'],
+    queryFn: async () => {
+      if (!groupId) return null;
+      const { data, error } = await client
+        .from('polls')
+        .select('*')
+        .eq('group_id', groupId)
+        .order('created_at', { ascending: false })
+        .limit(1);
+      if (error) throw error;
+      return data?.[0] ?? null;
+    },
+    enabled: SUPABASE_ENABLED && !!groupId,
+    staleTime: 30_000,
+    initialData: null,
+  });
+}
+
 export function useActivePoll({ groupId }: { groupId: string }) {
   return useQuery<Poll | null>({
     queryKey: ['polls', 'active', { groupId }],

--- a/apps/mobile/src/features/polls/index.ts
+++ b/apps/mobile/src/features/polls/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';


### PR DESCRIPTION
## Summary
- add `useLatestPoll` hook for fetching latest group poll
- wire `useLatestPoll` into Home screen
- re-export poll hooks from feature index

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c5207a508321949bdef98d536fbd